### PR TITLE
feat(i18n): add Russian locale foundation

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate",
     "db:studio": "drizzle-kit studio",
-    "typecheck": "next typegen && tsc --noEmit",
+    "typecheck": "rm -rf .next && next typegen && tsc --noEmit",
     "test:unit:smoke": "vitest run tests/unit/healthz.test.ts",
     "test:e2e:smoke": "playwright test tests/e2e/app-shell.spec.ts"
   },

--- a/src/app/app/page.tsx
+++ b/src/app/app/page.tsx
@@ -1,11 +1,15 @@
+import { getTranslations } from "@/modules/i18n";
 import { PageShell } from "@/shared/ui/page-shell";
+
+const common = getTranslations("common");
+const messages = getTranslations("app");
 
 export default function AppPage() {
   return (
     <PageShell
-      eyebrow="Route skeleton"
-      title="App"
-      description="This protected area is only a shell for future wishlist features."
+      eyebrow={common.routeSkeleton}
+      title={messages.dashboard.title}
+      description={messages.dashboard.description}
     />
   );
 }

--- a/src/app/app/reservations/page.tsx
+++ b/src/app/app/reservations/page.tsx
@@ -1,11 +1,15 @@
+import { getTranslations } from "@/modules/i18n";
 import { PageShell } from "@/shared/ui/page-shell";
+
+const common = getTranslations("common");
+const messages = getTranslations("app");
 
 export default function ReservationsPage() {
   return (
     <PageShell
-      eyebrow="Route skeleton"
-      title="Reservations"
-      description="Reservation views will be implemented in a later milestone."
+      eyebrow={common.routeSkeleton}
+      title={messages.reservations.title}
+      description={messages.reservations.description}
     />
   );
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,15 +1,18 @@
 import type { Metadata } from "next";
 import type { ReactNode } from "react";
+import { defaultLocale, getTranslations } from "@/modules/i18n";
 import "./globals.css";
 
+const metadataMessages = getTranslations("metadata");
+
 export const metadata: Metadata = {
-  title: "Wishka",
-  description: "Minimal, fast wishlist app.",
+  title: metadataMessages.title,
+  description: metadataMessages.description,
 };
 
 export default function RootLayout({ children }: Readonly<{ children: ReactNode }>) {
   return (
-    <html lang="ru">
+    <html lang={defaultLocale}>
       <body>{children}</body>
     </html>
   );

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,11 +1,15 @@
+import { getTranslations } from "@/modules/i18n";
 import { PageShell } from "@/shared/ui/page-shell";
+
+const common = getTranslations("common");
+const messages = getTranslations("app");
 
 export default function LoginPage() {
   return (
     <PageShell
-      eyebrow="Route skeleton"
-      title="Login"
-      description="Authentication UI will be introduced in a later milestone."
+      eyebrow={common.routeSkeleton}
+      title={messages.login.title}
+      description={messages.login.description}
     />
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,25 +1,27 @@
 import Link from "next/link";
+import { getTranslations } from "@/modules/i18n";
 import { PageShell } from "@/shared/ui/page-shell";
 
+const common = getTranslations("common");
+const messages = getTranslations("app");
+
 const routes = [
-  { href: "/login", label: "Login skeleton" },
-  { href: "/register", label: "Register skeleton" },
-  { href: "/app", label: "App shell" },
-  { href: "/app/reservations", label: "Reservations shell" },
-  { href: "/share/demo-token", label: "Public share shell" },
+  { href: "/login", label: messages.home.links.login },
+  { href: "/register", label: messages.home.links.register },
+  { href: "/app", label: messages.home.links.app },
+  { href: "/app/reservations", label: messages.home.links.reservations },
+  { href: "/share/demo-token", label: messages.home.links.share },
 ];
 
 export default function HomePage() {
   return (
     <PageShell
-      eyebrow="Wishka"
-      title="Minimal wishlist app foundation"
-      description="This route anchors the initial application shell for Milestone 1."
+      eyebrow={common.brand}
+      title={messages.home.title}
+      description={messages.home.description}
     >
       <div className="space-y-4">
-        <p className="text-sm leading-6 text-slate-600">
-          The routes below are placeholders only and intentionally contain no business logic yet.
-        </p>
+        <p className="text-sm leading-6 text-slate-600">{messages.home.routesHint}</p>
         <ul className="grid gap-3 sm:grid-cols-2">
           {routes.map((route) => (
             <li key={route.href}>

--- a/src/app/register/page.tsx
+++ b/src/app/register/page.tsx
@@ -1,11 +1,15 @@
+import { getTranslations } from "@/modules/i18n";
 import { PageShell } from "@/shared/ui/page-shell";
+
+const common = getTranslations("common");
+const messages = getTranslations("app");
 
 export default function RegisterPage() {
   return (
     <PageShell
-      eyebrow="Route skeleton"
-      title="Register"
-      description="Registration flow will be added when auth work starts."
+      eyebrow={common.routeSkeleton}
+      title={messages.register.title}
+      description={messages.register.description}
     />
   );
 }

--- a/src/app/share/[token]/page.tsx
+++ b/src/app/share/[token]/page.tsx
@@ -1,11 +1,15 @@
+import { getTranslations } from "@/modules/i18n";
 import { PageShell } from "@/shared/ui/page-shell";
+
+const common = getTranslations("common");
+const messages = getTranslations("app");
 
 export default function SharePage() {
   return (
     <PageShell
-      eyebrow="Route skeleton"
-      title="Shared wishlist"
-      description="Public share rendering will be added after the sharing milestone begins."
+      eyebrow={common.routeSkeleton}
+      title={messages.share.title}
+      description={messages.share.description}
     />
   );
 }

--- a/src/modules/i18n/README.md
+++ b/src/modules/i18n/README.md
@@ -1,0 +1,18 @@
+# i18n Foundation
+
+## Default Locale
+- `ru` is the default locale for the current foundation.
+
+## Structure
+- `src/modules/i18n/server.ts`: centralized access to locale dictionaries
+- `src/modules/i18n/dictionaries/ru/*`: namespace-based dictionaries for Russian
+
+## Namespaces
+- `common`: shared short labels
+- `metadata`: application metadata strings
+- `app`: current app shell route text
+
+## Growth Rule
+- Add future locales by mirroring the same namespace files, for example
+  `src/modules/i18n/dictionaries/en/*`, without changing the `getTranslations`
+  call sites.

--- a/src/modules/i18n/dictionaries/ru/app.ts
+++ b/src/modules/i18n/dictionaries/ru/app.ts
@@ -1,0 +1,34 @@
+export const app = {
+  home: {
+    title: "Минималистичный каркас Wishka",
+    description: "Эта страница фиксирует стартовый app shell для Milestone 1.",
+    routesHint: "Ниже только маршруты-заглушки без продуктовой логики.",
+    links: {
+      login: "Каркас входа",
+      register: "Каркас регистрации",
+      app: "Каркас приложения",
+      reservations: "Каркас бронирований",
+      share: "Каркас публичной ссылки",
+    },
+  },
+  login: {
+    title: "Вход",
+    description: "Интерфейс авторизации появится на следующем этапе auth.",
+  },
+  register: {
+    title: "Регистрация",
+    description: "Сценарий регистрации будет добавлен при начале auth milestone.",
+  },
+  dashboard: {
+    title: "Приложение",
+    description: "Это только каркас защищённой зоны для будущих возможностей Wishka.",
+  },
+  reservations: {
+    title: "Бронирования",
+    description: "Экран бронирований будет реализован в одном из следующих milestones.",
+  },
+  share: {
+    title: "Публичный вишлист",
+    description: "Публичный рендеринг списка появится после начала milestone sharing.",
+  },
+} as const;

--- a/src/modules/i18n/dictionaries/ru/common.ts
+++ b/src/modules/i18n/dictionaries/ru/common.ts
@@ -1,0 +1,4 @@
+export const common = {
+  brand: "Wishka",
+  routeSkeleton: "Каркас маршрута",
+} as const;

--- a/src/modules/i18n/dictionaries/ru/metadata.ts
+++ b/src/modules/i18n/dictionaries/ru/metadata.ts
@@ -1,0 +1,4 @@
+export const metadata = {
+  title: "Wishka",
+  description: "Минималистичное и быстрое приложение для вишлистов.",
+} as const;

--- a/src/modules/i18n/index.ts
+++ b/src/modules/i18n/index.ts
@@ -1,1 +1,1 @@
-export {};
+export { defaultLocale, getTranslations } from "@/modules/i18n/server";

--- a/src/modules/i18n/server.ts
+++ b/src/modules/i18n/server.ts
@@ -1,0 +1,20 @@
+import { app } from "@/modules/i18n/dictionaries/ru/app";
+import { common } from "@/modules/i18n/dictionaries/ru/common";
+import { metadata } from "@/modules/i18n/dictionaries/ru/metadata";
+
+const dictionaries = {
+  ru: {
+    app,
+    common,
+    metadata,
+  },
+} as const;
+
+export const defaultLocale = "ru";
+
+export type I18nLocale = keyof typeof dictionaries;
+export type I18nNamespace = keyof (typeof dictionaries)[typeof defaultLocale];
+
+export function getTranslations<TNamespace extends I18nNamespace>(namespace: TNamespace) {
+  return dictionaries[defaultLocale][namespace];
+}

--- a/tests/e2e/app-shell.spec.ts
+++ b/tests/e2e/app-shell.spec.ts
@@ -3,6 +3,6 @@ import { expect, test } from "@playwright/test";
 test("home route renders the app shell", async ({ page }) => {
   await page.goto("/");
 
-  await expect(page.getByRole("heading", { name: "Minimal wishlist app foundation" })).toBeVisible();
-  await expect(page.getByRole("link", { name: "Login skeleton" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Минималистичный каркас Wishka" })).toBeVisible();
+  await expect(page.getByRole("link", { name: "Каркас входа" })).toBeVisible();
 });


### PR DESCRIPTION
Closes #10 

Moves the current app shell strings into a centralized Russian i18n foundation for Milestone 1.

## What changed

- added a centralized i18n layer in `src/modules/i18n`
- introduced `ru` as the default locale
- added namespace-based dictionaries for:
  - `common`
  - `metadata`
  - `app`
- exposed a minimal server-side i18n API through `getTranslations(namespace)`
- moved user-facing strings out of the current routes and layout metadata into dictionaries
- updated the existing app shell routes to read text through the i18n layer instead of hardcoded strings

## How to verify

- inspect `src/modules/i18n/` and confirm the new i18n layer and Russian dictionaries are in place
- inspect the current routes and confirm user-facing strings are no longer hardcoded there
- run the app locally and open:
  - `/`
  - `/login`
  - `/register`
  - `/app`
  - `/app/reservations`
  - `/share/test-token`
- confirm the pages render correctly and display Russian text through the centralized i18n layer
- confirm metadata is still rendered correctly

## Tests

- `npm run typecheck`
- `npm run build`
- `npm run test:unit:smoke`
- `npm run test:e2e:smoke`

## Documentation

- added `src/modules/i18n/README.md`
- documented the initial dictionary structure and namespace approach