### PR TITLE
feat(ui): add light theme foundation

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4,21 +4,114 @@
 
 :root {
   color-scheme: light;
+
+  --color-bg-canvas: #f4f7fb;
+  --color-bg-surface: #ffffff;
+  --color-bg-subtle: #f8fafc;
+  --color-border-soft: #dbe4f0;
+  --color-border-strong: #c5d2e3;
+  --color-text-strong: #132033;
+  --color-text-base: #42546b;
+  --color-text-muted: #66788f;
+  --color-accent-soft: #e6eefc;
+  --color-focus-ring: rgba(59, 130, 246, 0.35);
+
+  --font-sans: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
+    "Segoe UI", sans-serif;
+  --font-size-body: 1rem;
+  --font-size-label: 0.875rem;
+  --font-size-title: clamp(2rem, 4vw, 2.75rem);
+  --line-height-body: 1.6;
+  --line-height-title: 1.1;
+
+  --space-1: 0.25rem;
+  --space-2: 0.5rem;
+  --space-3: 0.75rem;
+  --space-4: 1rem;
+  --space-5: 1.25rem;
+  --space-6: 1.5rem;
+  --space-8: 2rem;
+  --space-10: 2.5rem;
+  --space-16: 4rem;
+
+  --radius-sm: 0.75rem;
+  --radius-md: 1rem;
+  --radius-lg: 1.5rem;
+  --radius-xl: 2rem;
+
+  --shadow-surface: 0 18px 40px rgba(15, 23, 42, 0.06);
 }
 
-body {
-  margin: 0;
-  min-height: 100vh;
-  background: #f8fafc;
-  color: #0f172a;
-  font-family: Arial, Helvetica, sans-serif;
+@layer base {
+  * {
+    box-sizing: border-box;
+  }
+
+  html {
+    background: var(--color-bg-canvas);
+  }
+
+  body {
+    margin: 0;
+    min-height: 100vh;
+    background: radial-gradient(circle at top, #ffffff 0%, var(--color-bg-canvas) 55%);
+    color: var(--color-text-strong);
+    font-family: var(--font-sans);
+    font-size: var(--font-size-body);
+    line-height: var(--line-height-body);
+    text-rendering: optimizeLegibility;
+  }
+
+  a {
+    color: inherit;
+    text-decoration: none;
+  }
+
+  button,
+  a,
+  input,
+  textarea,
+  select {
+    transition:
+      border-color 120ms ease,
+      box-shadow 120ms ease,
+      background-color 120ms ease,
+      color 120ms ease;
+  }
+
+  :focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 4px var(--color-focus-ring);
+  }
 }
 
-a {
-  color: inherit;
-  text-decoration: none;
-}
+@layer components {
+  .ui-surface {
+    border: 1px solid var(--color-border-soft);
+    border-radius: var(--radius-xl);
+    background: linear-gradient(180deg, #ffffff 0%, #fbfdff 100%);
+    box-shadow: var(--shadow-surface);
+  }
 
-* {
-  box-sizing: border-box;
+  .ui-link-card {
+    display: block;
+    border: 1px solid var(--color-border-soft);
+    border-radius: var(--radius-lg);
+    background: var(--color-bg-subtle);
+    padding: var(--space-4) var(--space-5);
+    color: var(--color-text-base);
+    font-size: var(--font-size-label);
+    font-weight: 600;
+    line-height: 1.4;
+  }
+
+  .ui-link-card:hover {
+    border-color: var(--color-border-strong);
+    background: var(--color-bg-surface);
+    color: var(--color-text-strong);
+  }
+
+  .ui-link-card:focus-visible {
+    border-color: var(--color-border-strong);
+  }
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,5 @@
-import Link from "next/link";
 import { getTranslations } from "@/modules/i18n";
+import { LinkCard } from "@/shared/ui/link-card";
 import { PageShell } from "@/shared/ui/page-shell";
 
 const common = getTranslations("common");
@@ -20,17 +20,21 @@ export default function HomePage() {
       title={messages.home.title}
       description={messages.home.description}
     >
-      <div className="space-y-4">
-        <p className="text-sm leading-6 text-slate-600">{messages.home.routesHint}</p>
+      <div className="space-y-5">
+        <p
+          className="max-w-2xl"
+          style={{
+            color: "var(--color-text-base)",
+            fontSize: "var(--font-size-label)",
+            lineHeight: "var(--line-height-body)",
+          }}
+        >
+          {messages.home.routesHint}
+        </p>
         <ul className="grid gap-3 sm:grid-cols-2">
           {routes.map((route) => (
             <li key={route.href}>
-              <Link
-                href={route.href}
-                className="block rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm font-medium text-slate-700 transition hover:border-slate-300 hover:bg-white"
-              >
-                {route.label}
-              </Link>
+              <LinkCard href={route.href} label={route.label} />
             </li>
           ))}
         </ul>

--- a/src/modules/ui/README.md
+++ b/src/modules/ui/README.md
@@ -1,0 +1,16 @@
+# UI Foundation
+
+## Theme Scope
+- Light theme only for now.
+
+## Tokens
+- Theme tokens live in `src/app/globals.css` as CSS custom properties.
+- Current token groups: colors, typography, spacing, radii, focus states.
+
+## Foundation Blocks
+- `PageShell`: base page container and surface composition.
+- `LinkCard`: neutral interactive card for route-level navigation.
+
+## Growth Rule
+- Add future theme tokens by extending the same custom property contract.
+- Keep new primitives small and driven by real reuse in the app shell.

--- a/src/shared/ui/link-card.tsx
+++ b/src/shared/ui/link-card.tsx
@@ -1,0 +1,14 @@
+import Link from "next/link";
+
+type LinkCardProps = {
+  href: string;
+  label: string;
+};
+
+export function LinkCard({ href, label }: LinkCardProps) {
+  return (
+    <Link href={href} className="ui-link-card">
+      {label}
+    </Link>
+  );
+}

--- a/src/shared/ui/page-shell.tsx
+++ b/src/shared/ui/page-shell.tsx
@@ -9,15 +9,40 @@ type PageShellProps = {
 
 export function PageShell({ eyebrow, title, description, children }: PageShellProps) {
   return (
-    <main className="mx-auto flex min-h-screen max-w-4xl flex-col px-6 py-16 sm:px-10">
-      <div className="max-w-2xl rounded-3xl border border-slate-200 bg-white p-8 shadow-sm sm:p-10">
+    <main className="mx-auto flex min-h-screen max-w-5xl flex-col justify-center px-6 py-16 sm:px-10">
+      <div className="ui-surface max-w-3xl p-8 sm:p-10 lg:p-12">
         {eyebrow ? (
-          <p className="text-sm font-medium uppercase tracking-[0.2em] text-slate-500">{eyebrow}</p>
+          <p
+            className="uppercase tracking-[0.22em]"
+            style={{
+              color: "var(--color-text-muted)",
+              fontSize: "var(--font-size-label)",
+              fontWeight: 600,
+            }}
+          >
+            {eyebrow}
+          </p>
         ) : null}
-        <h1 className="mt-3 text-3xl font-semibold tracking-tight text-slate-950 sm:text-4xl">
+        <h1
+          className="mt-3 max-w-2xl font-semibold tracking-tight"
+          style={{
+            color: "var(--color-text-strong)",
+            fontSize: "var(--font-size-title)",
+            lineHeight: "var(--line-height-title)",
+          }}
+        >
           {title}
         </h1>
-        <p className="mt-4 text-base leading-7 text-slate-600">{description}</p>
+        <p
+          className="mt-4 max-w-2xl"
+          style={{
+            color: "var(--color-text-base)",
+            fontSize: "var(--font-size-body)",
+            lineHeight: "var(--line-height-body)",
+          }}
+        >
+          {description}
+        </p>
         {children ? <div className="mt-8">{children}</div> : null}
       </div>
     </main>


### PR DESCRIPTION
Closes #11 

Adds the light-theme UI foundation for Milestone 1 with reusable design tokens and minimal UI primitives for the current app shell.

## What changed

- introduced centralized light-theme design tokens in `src/app/globals.css`
- added token groups for colors, typography, spacing, radii, and focus states
- updated `PageShell` to use the new UI foundation
- added `LinkCard` as a minimal reusable interactive primitive for route-level navigation
- updated the home route to use the new UI primitives and token-based styling
- aligned the current route skeleton pages with the new light-theme foundation

## How to verify

- inspect `src/app/globals.css` and confirm the design tokens are defined centrally
- inspect `src/shared/ui/page-shell.tsx` and `src/shared/ui/link-card.tsx`
- run the app locally and open:
  - `/`
  - `/login`
  - `/register`
  - `/app`
  - `/app/reservations`
  - `/share/test-token`
- confirm the pages render with a consistent light-theme foundation on desktop and mobile widths
- confirm focus-visible states are present and visually consistent

## Tests

- `npm run typecheck`
- `npm run build`
- `npm run test:unit:smoke`
- `npm run test:e2e:smoke`

## Documentation

- added `src/modules/ui/README.md`
- documented the initial UI foundation and token-based approach