### PR TITLE
feat(auth): add password hashing helpers

### DIFF
--- a/src/modules/auth/README.md
+++ b/src/modules/auth/README.md
@@ -1,0 +1,11 @@
+# Auth Module
+
+## Current Foundation
+- `db/schema.ts`: auth-owned database tables for `users` and `sessions`
+- `server/password.ts`: reusable password hashing and verification helpers
+- `server/email.ts`: shared email normalization for auth entry points
+
+## Scope
+- Keep auth helpers inside the `auth` module until there is a proven reuse case
+- Registration, login, logout, and session guards should build on these helpers
+  instead of duplicating password or email handling

--- a/src/modules/auth/index.ts
+++ b/src/modules/auth/index.ts
@@ -1,1 +1,6 @@
 export { sessions, users } from "@/modules/auth/db/schema";
+export {
+  hashPassword,
+  normalizeEmail,
+  verifyPassword,
+} from "@/modules/auth/server";

--- a/src/modules/auth/server/email.ts
+++ b/src/modules/auth/server/email.ts
@@ -1,0 +1,3 @@
+export function normalizeEmail(email: string): string {
+  return email.trim().toLowerCase();
+}

--- a/src/modules/auth/server/index.ts
+++ b/src/modules/auth/server/index.ts
@@ -1,0 +1,2 @@
+export { normalizeEmail } from "@/modules/auth/server/email";
+export { hashPassword, verifyPassword } from "@/modules/auth/server/password";

--- a/src/modules/auth/server/password.ts
+++ b/src/modules/auth/server/password.ts
@@ -1,0 +1,45 @@
+import { randomBytes, scrypt as scryptCallback, timingSafeEqual } from "node:crypto";
+import { promisify } from "node:util";
+
+const scrypt = promisify(scryptCallback);
+
+const PASSWORD_KEY_LENGTH = 64;
+const PASSWORD_SALT_LENGTH = 16;
+const PASSWORD_HASH_PREFIX = "scrypt";
+export async function hashPassword(password: string): Promise<string> {
+  const salt = randomBytes(PASSWORD_SALT_LENGTH);
+  const derivedKey = (await scrypt(password, salt, PASSWORD_KEY_LENGTH)) as Buffer;
+
+  return [
+    PASSWORD_HASH_PREFIX,
+    salt.toString("hex"),
+    derivedKey.toString("hex"),
+  ].join("$");
+}
+
+export async function verifyPassword(
+  password: string,
+  passwordHash: string,
+): Promise<boolean> {
+  const [prefix, saltHex, storedHashHex] = passwordHash.split("$");
+
+  if (
+    prefix !== PASSWORD_HASH_PREFIX ||
+    !saltHex ||
+    !storedHashHex ||
+    storedHashHex.length !== PASSWORD_KEY_LENGTH * 2
+  ) {
+    return false;
+  }
+
+  const salt = Buffer.from(saltHex, "hex");
+  const storedHash = Buffer.from(storedHashHex, "hex");
+
+  if (salt.length !== PASSWORD_SALT_LENGTH || storedHash.length !== PASSWORD_KEY_LENGTH) {
+    return false;
+  }
+
+  const derivedKey = (await scrypt(password, salt, PASSWORD_KEY_LENGTH)) as Buffer;
+
+  return timingSafeEqual(storedHash, derivedKey);
+}

--- a/tests/unit/auth-password.test.ts
+++ b/tests/unit/auth-password.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import {
+  hashPassword,
+  normalizeEmail,
+  verifyPassword,
+} from "../../src/modules/auth/server";
+
+describe("auth password helpers", () => {
+  it("hashes and verifies a password", async () => {
+    const password = "correct horse battery staple";
+    const passwordHash = await hashPassword(password);
+
+    expect(passwordHash).toContain("$");
+    await expect(verifyPassword(password, passwordHash)).resolves.toBe(true);
+    await expect(verifyPassword("wrong-password", passwordHash)).resolves.toBe(false);
+  });
+
+  it("rejects malformed password hashes", async () => {
+    await expect(verifyPassword("password", "invalid-hash")).resolves.toBe(false);
+  });
+});
+
+describe("auth email helper", () => {
+  it("normalizes email input for auth flows", () => {
+    expect(normalizeEmail("  USER@Example.COM ")).toBe("user@example.com");
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,12 @@
+import path from "node:path";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./src"),
+    },
+  },
   test: {
     environment: "node",
     globals: true,


### PR DESCRIPTION
Closes #20 

Add reusable auth helpers for password hashing, verification, and email normalization so the upcoming registration and login flows can share one small server-side foundation. Keep the API minimal, module-owned, and covered by unit tests.

## What changed

- added password hashing and password verification helpers under `src/modules/auth/server/password.ts`
- added email normalization helper under `src/modules/auth/server/email.ts`
- exposed the server-side auth helpers through `src/modules/auth/server/index.ts`
- updated auth module exports so the next auth PRs can reuse the helpers from a stable entry point
- added focused unit coverage for password hashing and verification
- documented the auth module foundation in `src/modules/auth/README.md`

## How to verify

- inspect `src/modules/auth/server/password.ts` and confirm the module exposes reusable hashing and verification helpers
- inspect `src/modules/auth/server/email.ts` and confirm email normalization is handled centrally
- inspect `src/modules/auth/server/index.ts` and confirm the helpers are exported from one module-owned entry point
- confirm the implementation uses `scrypt` with per-password random salt and safe comparison during verification
- confirm the current app still typechecks successfully

## Tests

- `npm run typecheck`
- `npx vitest run tests/unit/auth-password.test.ts`

## Documentation

- added `src/modules/auth/README.md`
- documented the initial auth helper foundation and expected reuse path for the next auth milestones