### PR TITLE
feat(auth): add email registration flow

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -114,4 +114,78 @@
   .ui-link-card:focus-visible {
     border-color: var(--color-border-strong);
   }
+
+  .ui-form {
+    display: grid;
+    gap: var(--space-5);
+    max-width: 28rem;
+  }
+
+  .ui-field {
+    display: grid;
+    gap: var(--space-2);
+  }
+
+  .ui-label {
+    color: var(--color-text-strong);
+    font-size: var(--font-size-label);
+    font-weight: 600;
+  }
+
+  .ui-input {
+    width: 100%;
+    border: 1px solid var(--color-border-soft);
+    border-radius: var(--radius-md);
+    background: var(--color-bg-surface);
+    padding: var(--space-4);
+    color: var(--color-text-strong);
+    font: inherit;
+  }
+
+  .ui-input::placeholder {
+    color: var(--color-text-muted);
+  }
+
+  .ui-input:hover,
+  .ui-input:focus-visible {
+    border-color: var(--color-border-strong);
+  }
+
+  .ui-button {
+    width: fit-content;
+    border: 1px solid transparent;
+    border-radius: var(--radius-md);
+    background: var(--color-text-strong);
+    padding: var(--space-4) var(--space-5);
+    color: #ffffff;
+    font: inherit;
+    font-weight: 600;
+    cursor: pointer;
+  }
+
+  .ui-button:hover {
+    background: #1f3049;
+  }
+
+  .ui-note {
+    color: var(--color-text-muted);
+    font-size: var(--font-size-label);
+  }
+
+  .ui-message {
+    border: 1px solid var(--color-border-soft);
+    border-radius: var(--radius-md);
+    padding: var(--space-4);
+    font-size: var(--font-size-label);
+  }
+
+  .ui-message-success {
+    background: #f1f9f3;
+    color: #245033;
+  }
+
+  .ui-message-error {
+    background: #fff4f4;
+    color: #8a2431;
+  }
 }

--- a/src/app/register/page.tsx
+++ b/src/app/register/page.tsx
@@ -1,15 +1,102 @@
+import { redirect } from "next/navigation";
+import { MIN_PASSWORD_LENGTH, registerUser } from "@/modules/auth";
 import { getTranslations } from "@/modules/i18n";
 import { PageShell } from "@/shared/ui/page-shell";
 
 const common = getTranslations("common");
 const messages = getTranslations("app");
 
-export default function RegisterPage() {
+type RegisterPageProps = {
+  searchParams?: Promise<{
+    status?: string;
+    error?: string;
+  }>;
+};
+
+export default async function RegisterPage({ searchParams }: RegisterPageProps) {
+  const params = searchParams ? await searchParams : undefined;
+  const status = params?.status;
+  const errorCode = params?.error;
+
   return (
     <PageShell
       eyebrow={common.routeSkeleton}
       title={messages.register.title}
       description={messages.register.description}
-    />
+    >
+      {status === "success" ? (
+        <p className="ui-message ui-message-success">{messages.register.successMessage}</p>
+      ) : null}
+      {errorCode ? (
+        <p className="ui-message ui-message-error">{getRegisterErrorMessage(errorCode)}</p>
+      ) : null}
+      <form action={registerAction} className="ui-form">
+        <div className="ui-field">
+          <label className="ui-label" htmlFor="email">
+            {messages.register.emailLabel}
+          </label>
+          <input
+            id="email"
+            name="email"
+            type="email"
+            autoComplete="email"
+            className="ui-input"
+            required
+          />
+        </div>
+        <div className="ui-field">
+          <label className="ui-label" htmlFor="password">
+            {messages.register.passwordLabel}
+          </label>
+          <input
+            id="password"
+            name="password"
+            type="password"
+            autoComplete="new-password"
+            minLength={MIN_PASSWORD_LENGTH}
+            className="ui-input"
+            required
+          />
+          <p className="ui-note">{messages.register.minPasswordHint}</p>
+        </div>
+        <button type="submit" className="ui-button">
+          {messages.register.submitLabel}
+        </button>
+      </form>
+    </PageShell>
   );
+}
+
+async function registerAction(formData: FormData) {
+  "use server";
+
+  const result = await registerUser({
+    email: getFormValue(formData, "email"),
+    password: getFormValue(formData, "password"),
+  });
+
+  if (result.status === "success") {
+    redirect("/register?status=success");
+  }
+
+  redirect(`/register?error=${result.code}`);
+}
+
+function getFormValue(formData: FormData, fieldName: string): string {
+  const value = formData.get(fieldName);
+
+  return typeof value === "string" ? value : "";
+}
+
+function getRegisterErrorMessage(errorCode: string): string {
+  switch (errorCode) {
+    case "invalid-email":
+      return messages.register.errors.invalidEmail;
+    case "password-too-short":
+      return messages.register.errors.passwordTooShort;
+    case "email-taken":
+      return messages.register.errors.emailTaken;
+    default:
+      return messages.register.errors.unknown;
+  }
 }

--- a/src/app/register/page.tsx
+++ b/src/app/register/page.tsx
@@ -1,5 +1,5 @@
 import { redirect } from "next/navigation";
-import { MIN_PASSWORD_LENGTH, registerUser } from "@/modules/auth";
+import { MIN_PASSWORD_LENGTH } from "@/modules/auth/server/register-input";
 import { getTranslations } from "@/modules/i18n";
 import { PageShell } from "@/shared/ui/page-shell";
 
@@ -69,6 +69,8 @@ export default async function RegisterPage({ searchParams }: RegisterPageProps) 
 
 async function registerAction(formData: FormData) {
   "use server";
+
+  const { registerUser } = await import("@/modules/auth/server/register");
 
   const result = await registerUser({
     email: getFormValue(formData, "email"),

--- a/src/modules/auth/README.md
+++ b/src/modules/auth/README.md
@@ -4,6 +4,8 @@
 - `db/schema.ts`: auth-owned database tables for `users` and `sessions`
 - `server/password.ts`: reusable password hashing and verification helpers
 - `server/email.ts`: shared email normalization for auth entry points
+- `server/register.ts`: minimal server-side registration helper built on auth
+  schema and helpers
 
 ## Scope
 - Keep auth helpers inside the `auth` module until there is a proven reuse case

--- a/src/modules/auth/index.ts
+++ b/src/modules/auth/index.ts
@@ -1,6 +1,9 @@
 export { sessions, users } from "@/modules/auth/db/schema";
 export {
   hashPassword,
+  MIN_PASSWORD_LENGTH,
   normalizeEmail,
+  registerUser,
+  validateRegisterUserInput,
   verifyPassword,
 } from "@/modules/auth/server";

--- a/src/modules/auth/server/index.ts
+++ b/src/modules/auth/server/index.ts
@@ -1,2 +1,9 @@
 export { normalizeEmail } from "@/modules/auth/server/email";
 export { hashPassword, verifyPassword } from "@/modules/auth/server/password";
+export {
+  MIN_PASSWORD_LENGTH,
+  validateRegisterUserInput,
+} from "@/modules/auth/server/register-input";
+export {
+  registerUser,
+} from "@/modules/auth/server/register";

--- a/src/modules/auth/server/register-input.ts
+++ b/src/modules/auth/server/register-input.ts
@@ -1,0 +1,32 @@
+import { normalizeEmail } from "@/modules/auth/server/email";
+
+const MIN_PASSWORD_LENGTH = 8;
+
+export type RegisterUserResult =
+  | { status: "success" }
+  | { status: "error"; code: "invalid-email" | "password-too-short" | "email-taken" | "unknown" };
+
+type RegisterUserInput = {
+  email: string;
+  password: string;
+};
+
+export function validateRegisterUserInput({ email, password }: RegisterUserInput): RegisterUserResult {
+  const normalizedEmail = normalizeEmail(email);
+
+  if (!isValidEmail(normalizedEmail)) {
+    return { status: "error", code: "invalid-email" };
+  }
+
+  if (password.length < MIN_PASSWORD_LENGTH) {
+    return { status: "error", code: "password-too-short" };
+  }
+
+  return { status: "success" };
+}
+
+function isValidEmail(email: string): boolean {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
+}
+
+export { MIN_PASSWORD_LENGTH };

--- a/src/modules/auth/server/register.ts
+++ b/src/modules/auth/server/register.ts
@@ -1,0 +1,59 @@
+"use server";
+
+import { eq } from "drizzle-orm";
+import { DatabaseError } from "pg";
+import { users } from "@/modules/auth/db/schema";
+import { normalizeEmail } from "@/modules/auth/server/email";
+import { hashPassword } from "@/modules/auth/server/password";
+import {
+  type RegisterUserResult,
+  validateRegisterUserInput,
+} from "@/modules/auth/server/register-input";
+import { db } from "@/shared/db";
+
+type RegisterUserInput = {
+  email: string;
+  password: string;
+};
+
+export async function registerUser({ email, password }: RegisterUserInput): Promise<RegisterUserResult> {
+  const normalizedEmail = normalizeEmail(email);
+  const validationResult = validateRegisterUserInput({
+    email: normalizedEmail,
+    password,
+  });
+
+  if (validationResult.status === "error") {
+    return validationResult;
+  }
+
+  const existingUser = await db.query.users.findFirst({
+    columns: { id: true },
+    where: eq(users.email, normalizedEmail),
+  });
+
+  if (existingUser) {
+    return { status: "error", code: "email-taken" };
+  }
+
+  const passwordHash = await hashPassword(password);
+
+  try {
+    await db.insert(users).values({
+      email: normalizedEmail,
+      passwordHash,
+    });
+
+    return { status: "success" };
+  } catch (error) {
+    if (isUniqueEmailViolation(error)) {
+      return { status: "error", code: "email-taken" };
+    }
+
+    return { status: "error", code: "unknown" };
+  }
+}
+
+function isUniqueEmailViolation(error: unknown): boolean {
+  return error instanceof DatabaseError && error.code === "23505";
+}

--- a/src/modules/i18n/dictionaries/ru/app.ts
+++ b/src/modules/i18n/dictionaries/ru/app.ts
@@ -17,7 +17,18 @@ export const app = {
   },
   register: {
     title: "Регистрация",
-    description: "Сценарий регистрации будет добавлен при начале auth milestone.",
+    description: "Создайте аккаунт по email и паролю, чтобы позже управлять своим вишлистом.",
+    emailLabel: "Email",
+    passwordLabel: "Пароль",
+    submitLabel: "Создать аккаунт",
+    minPasswordHint: "Минимум 8 символов.",
+    successMessage: "Аккаунт создан. Теперь можно перейти к будущему сценарию входа.",
+    errors: {
+      invalidEmail: "Введите корректный email.",
+      passwordTooShort: "Пароль должен быть не короче 8 символов.",
+      emailTaken: "Пользователь с таким email уже существует.",
+      unknown: "Не удалось завершить регистрацию. Попробуйте ещё раз.",
+    },
   },
   dashboard: {
     title: "Приложение",

--- a/src/shared/db/client.ts
+++ b/src/shared/db/client.ts
@@ -1,5 +1,6 @@
 import { drizzle } from "drizzle-orm/node-postgres";
 import { Pool } from "pg";
+import * as authSchema from "@/modules/auth/db/schema";
 import { getDatabaseEnv } from "@/shared/db/env";
 
 const { databaseUrl, databaseSsl } = getDatabaseEnv();
@@ -9,4 +10,8 @@ export const pool = new Pool({
   ssl: databaseSsl ? { rejectUnauthorized: false } : undefined,
 });
 
-export const db = drizzle(pool);
+export const db = drizzle(pool, {
+  schema: {
+    ...authSchema,
+  },
+});

--- a/tests/unit/auth-password.test.ts
+++ b/tests/unit/auth-password.test.ts
@@ -1,9 +1,6 @@
 import { describe, expect, it } from "vitest";
-import {
-  hashPassword,
-  normalizeEmail,
-  verifyPassword,
-} from "../../src/modules/auth/server";
+import { hashPassword, verifyPassword } from "../../src/modules/auth/server/password";
+import { normalizeEmail } from "../../src/modules/auth/server/email";
 
 describe("auth password helpers", () => {
   it("hashes and verifies a password", async () => {

--- a/tests/unit/auth-register.test.ts
+++ b/tests/unit/auth-register.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import {
+  MIN_PASSWORD_LENGTH,
+  validateRegisterUserInput,
+} from "../../src/modules/auth/server/register-input";
+
+describe("register user validation", () => {
+  it("rejects invalid email", () => {
+    expect(
+      validateRegisterUserInput({
+        email: "not-an-email",
+        password: "password123",
+      }),
+    ).toEqual({ status: "error", code: "invalid-email" });
+  });
+
+  it("rejects short password", () => {
+    expect(
+      validateRegisterUserInput({
+        email: "user@example.com",
+        password: "x".repeat(MIN_PASSWORD_LENGTH - 1),
+      }),
+    ).toEqual({ status: "error", code: "password-too-short" });
+  });
+
+  it("accepts normalized valid credentials", () => {
+    expect(
+      validateRegisterUserInput({
+        email: " User@Example.com ",
+        password: "password123",
+      }),
+    ).toEqual({ status: "success" });
+  });
+});


### PR DESCRIPTION
Closes #21 

Implement a minimal server-first registration flow on `/register` using the existing auth helpers and database foundation. Keep the scope limited to validation, duplicate email handling, user creation, and a simple in-place success or error state without sessions or login behavior.

## What changed

- replaced the `/register` route skeleton with a working server-first registration flow
- added server-side registration input validation
- added server-side user creation logic in the auth module
- reused the existing auth helpers for:
  - email normalization
  - password hashing
- stored only the password hash in the `users` table
- added duplicate email handling with a user-friendly error result
- kept the success and error UX on the same `/register` page via redirect-based status handling
- updated Russian UI strings for the registration flow
- documented the new auth module behavior

## How to verify

- open `/register`
- submit a valid email and password
- confirm the user is created successfully
- confirm the page returns to `/register` with a success state
- submit the same email again
- confirm the page shows a user-friendly duplicate email error
- submit invalid input, such as an invalid email or a too-short password
- confirm validation errors are handled server-side
- inspect the database and confirm only `password_hash` is stored, not the raw password

## Tests

- `npm run typecheck`
- `npx vitest run tests/unit/auth-password.test.ts tests/unit/auth-register.test.ts`

## Documentation

- updated `src/modules/auth/README.md`
- updated Russian app dictionary entries for the registration flow