### PR TITLE
feat(auth): add login and logout flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@ The format is based on Keep a Changelog, and this project follows SemVer.
 
 ## [Unreleased]
 
-### Planned
-- Milestone 2: auth core.
+### Added
+- Minimal login/logout flow with server-side sessions and HTTP-only auth cookie.
 
 ## [0.2.0] - 2026-04-10
 

--- a/src/app/app/page.tsx
+++ b/src/app/app/page.tsx
@@ -1,3 +1,5 @@
+import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
 import { getTranslations } from "@/modules/i18n";
 import { PageShell } from "@/shared/ui/page-shell";
 
@@ -10,6 +12,27 @@ export default function AppPage() {
       eyebrow={common.routeSkeleton}
       title={messages.dashboard.title}
       description={messages.dashboard.description}
-    />
+    >
+      <form action={logoutAction}>
+        <button type="submit" className="ui-button">
+          {messages.dashboard.logoutLabel}
+        </button>
+      </form>
+    </PageShell>
   );
+}
+
+async function logoutAction() {
+  "use server";
+
+  const cookieStore = await cookies();
+  const [{ AUTH_SESSION_COOKIE_NAME, clearSessionCookie }, { logoutUser }] = await Promise.all([
+    import("@/modules/auth/server/session"),
+    import("@/modules/auth/server/logout"),
+  ]);
+
+  await logoutUser(cookieStore.get(AUTH_SESSION_COOKIE_NAME)?.value);
+  await clearSessionCookie();
+
+  redirect("/login?status=logged-out");
 }

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,15 +1,103 @@
+import { redirect } from "next/navigation";
 import { getTranslations } from "@/modules/i18n";
 import { PageShell } from "@/shared/ui/page-shell";
 
 const common = getTranslations("common");
 const messages = getTranslations("app");
 
-export default function LoginPage() {
+type LoginPageProps = {
+  searchParams?: Promise<{
+    status?: string;
+    error?: string;
+  }>;
+};
+
+export default async function LoginPage({ searchParams }: LoginPageProps) {
+  const params = searchParams ? await searchParams : undefined;
+  const status = params?.status;
+  const errorCode = params?.error;
+
   return (
     <PageShell
       eyebrow={common.routeSkeleton}
       title={messages.login.title}
       description={messages.login.description}
-    />
+    >
+      {status === "logged-out" ? (
+        <p className="ui-message ui-message-success">{messages.login.loggedOutMessage}</p>
+      ) : null}
+      {errorCode ? (
+        <p className="ui-message ui-message-error">{getLoginErrorMessage(errorCode)}</p>
+      ) : null}
+      <form action={loginAction} className="ui-form">
+        <div className="ui-field">
+          <label className="ui-label" htmlFor="email">
+            {messages.login.emailLabel}
+          </label>
+          <input
+            id="email"
+            name="email"
+            type="email"
+            autoComplete="email"
+            className="ui-input"
+            required
+          />
+        </div>
+        <div className="ui-field">
+          <label className="ui-label" htmlFor="password">
+            {messages.login.passwordLabel}
+          </label>
+          <input
+            id="password"
+            name="password"
+            type="password"
+            autoComplete="current-password"
+            className="ui-input"
+            required
+          />
+        </div>
+        <button type="submit" className="ui-button">
+          {messages.login.submitLabel}
+        </button>
+      </form>
+    </PageShell>
   );
+}
+
+async function loginAction(formData: FormData) {
+  "use server";
+
+  const [{ loginUser }, { setSessionCookie }] = await Promise.all([
+    import("@/modules/auth/server/login"),
+    import("@/modules/auth/server/session"),
+  ]);
+
+  const result = await loginUser({
+    email: getFormValue(formData, "email"),
+    password: getFormValue(formData, "password"),
+  });
+
+  if (result.status === "success") {
+    await setSessionCookie(result.sessionToken, result.expiresAt);
+    redirect("/app");
+  }
+
+  redirect(`/login?error=${result.code}`);
+}
+
+function getFormValue(formData: FormData, fieldName: string): string {
+  const value = formData.get(fieldName);
+
+  return typeof value === "string" ? value : "";
+}
+
+function getLoginErrorMessage(errorCode: string): string {
+  switch (errorCode) {
+    case "invalid-input":
+      return messages.login.errors.invalidInput;
+    case "invalid-credentials":
+      return messages.login.errors.invalidCredentials;
+    default:
+      return messages.login.errors.unknown;
+  }
 }

--- a/src/modules/auth/README.md
+++ b/src/modules/auth/README.md
@@ -3,9 +3,14 @@
 ## Current Foundation
 - `db/schema.ts`: auth-owned database tables for `users` and `sessions`
 - `server/password.ts`: reusable password hashing and verification helpers
-- `server/email.ts`: shared email normalization for auth entry points
+- `server/email.ts`: shared email normalization and format validation for auth
+  entry points
 - `server/register.ts`: minimal server-side registration helper built on auth
   schema and helpers
+- `server/login.ts`: minimal server-side login helper that validates
+  credentials and creates a session
+- `server/session.ts`: server-side session persistence and cookie helpers
+- `server/logout.ts`: minimal logout helper that removes the current session
 
 ## Scope
 - Keep auth helpers inside the `auth` module until there is a proven reuse case

--- a/src/modules/auth/index.ts
+++ b/src/modules/auth/index.ts
@@ -1,9 +1,19 @@
 export { sessions, users } from "@/modules/auth/db/schema";
 export {
   hashPassword,
+  isValidEmail,
+  loginUser,
+  type LoginUserResult,
   MIN_PASSWORD_LENGTH,
   normalizeEmail,
   registerUser,
+  logoutUser,
+  AUTH_SESSION_COOKIE_NAME,
+  clearSessionCookie,
+  createSession,
+  deleteSession,
+  setSessionCookie,
+  validateLoginUserInput,
   validateRegisterUserInput,
   verifyPassword,
 } from "@/modules/auth/server";

--- a/src/modules/auth/server/email.ts
+++ b/src/modules/auth/server/email.ts
@@ -1,3 +1,7 @@
 export function normalizeEmail(email: string): string {
   return email.trim().toLowerCase();
 }
+
+export function isValidEmail(email: string): boolean {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
+}

--- a/src/modules/auth/server/index.ts
+++ b/src/modules/auth/server/index.ts
@@ -1,9 +1,22 @@
-export { normalizeEmail } from "@/modules/auth/server/email";
+export { isValidEmail, normalizeEmail } from "@/modules/auth/server/email";
+export {
+  type LoginUserResult,
+  validateLoginUserInput,
+} from "@/modules/auth/server/login-input";
+export { loginUser } from "@/modules/auth/server/login";
+export { logoutUser } from "@/modules/auth/server/logout";
 export { hashPassword, verifyPassword } from "@/modules/auth/server/password";
 export {
   MIN_PASSWORD_LENGTH,
   validateRegisterUserInput,
 } from "@/modules/auth/server/register-input";
+export {
+  AUTH_SESSION_COOKIE_NAME,
+  clearSessionCookie,
+  createSession,
+  deleteSession,
+  setSessionCookie,
+} from "@/modules/auth/server/session";
 export {
   registerUser,
 } from "@/modules/auth/server/register";

--- a/src/modules/auth/server/login-input.ts
+++ b/src/modules/auth/server/login-input.ts
@@ -1,0 +1,20 @@
+import { isValidEmail, normalizeEmail } from "@/modules/auth/server/email";
+
+export type LoginUserResult =
+  | { status: "success"; sessionToken: string; expiresAt: Date }
+  | { status: "error"; code: "invalid-input" | "invalid-credentials" | "unknown" };
+
+type LoginUserInput = {
+  email: string;
+  password: string;
+};
+
+export function validateLoginUserInput({ email, password }: LoginUserInput) {
+  const normalizedEmail = normalizeEmail(email);
+
+  if (!isValidEmail(normalizedEmail) || password.length === 0) {
+    return { status: "error", code: "invalid-input" } as const;
+  }
+
+  return { status: "success" } as const;
+}

--- a/src/modules/auth/server/login.ts
+++ b/src/modules/auth/server/login.ts
@@ -1,0 +1,57 @@
+import { eq } from "drizzle-orm";
+import { users } from "@/modules/auth/db/schema";
+import { normalizeEmail } from "@/modules/auth/server/email";
+import {
+  type LoginUserResult,
+  validateLoginUserInput,
+} from "@/modules/auth/server/login-input";
+import { verifyPassword } from "@/modules/auth/server/password";
+import { createSession } from "@/modules/auth/server/session";
+import { db } from "@/shared/db";
+
+type LoginUserInput = {
+  email: string;
+  password: string;
+};
+
+export async function loginUser({ email, password }: LoginUserInput): Promise<LoginUserResult> {
+  const normalizedEmail = normalizeEmail(email);
+  const validationResult = validateLoginUserInput({
+    email: normalizedEmail,
+    password,
+  });
+
+  if (validationResult.status === "error") {
+    return validationResult;
+  }
+
+  try {
+    const user = await db.query.users.findFirst({
+      columns: {
+        id: true,
+        passwordHash: true,
+      },
+      where: eq(users.email, normalizedEmail),
+    });
+
+    if (!user) {
+      return { status: "error", code: "invalid-credentials" };
+    }
+
+    const isValidPassword = await verifyPassword(password, user.passwordHash);
+
+    if (!isValidPassword) {
+      return { status: "error", code: "invalid-credentials" };
+    }
+
+    const session = await createSession(user.id);
+
+    return {
+      status: "success",
+      sessionToken: session.sessionToken,
+      expiresAt: session.expiresAt,
+    };
+  } catch {
+    return { status: "error", code: "unknown" };
+  }
+}

--- a/src/modules/auth/server/logout.ts
+++ b/src/modules/auth/server/logout.ts
@@ -1,0 +1,9 @@
+import { deleteSession } from "@/modules/auth/server/session";
+
+export async function logoutUser(sessionToken: string | undefined) {
+  if (!sessionToken) {
+    return;
+  }
+
+  await deleteSession(sessionToken);
+}

--- a/src/modules/auth/server/register-input.ts
+++ b/src/modules/auth/server/register-input.ts
@@ -1,4 +1,4 @@
-import { normalizeEmail } from "@/modules/auth/server/email";
+import { isValidEmail, normalizeEmail } from "@/modules/auth/server/email";
 
 const MIN_PASSWORD_LENGTH = 8;
 
@@ -24,9 +24,4 @@ export function validateRegisterUserInput({ email, password }: RegisterUserInput
 
   return { status: "success" };
 }
-
-function isValidEmail(email: string): boolean {
-  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
-}
-
 export { MIN_PASSWORD_LENGTH };

--- a/src/modules/auth/server/session.ts
+++ b/src/modules/auth/server/session.ts
@@ -1,0 +1,55 @@
+import { randomBytes } from "node:crypto";
+import { cookies } from "next/headers";
+import { eq } from "drizzle-orm";
+import { sessions } from "@/modules/auth/db/schema";
+import { db } from "@/shared/db";
+
+export const AUTH_SESSION_COOKIE_NAME = "wishka_session";
+
+const SESSION_TOKEN_LENGTH = 32;
+const SESSION_TTL_DAYS = 30;
+const SESSION_TTL_MS = SESSION_TTL_DAYS * 24 * 60 * 60 * 1000;
+
+export async function createSession(userId: string) {
+  const sessionToken = randomBytes(SESSION_TOKEN_LENGTH).toString("base64url");
+  const expiresAt = new Date(Date.now() + SESSION_TTL_MS);
+
+  await db.insert(sessions).values({
+    userId,
+    sessionToken,
+    expiresAt,
+  });
+
+  return {
+    sessionToken,
+    expiresAt,
+  };
+}
+
+export async function deleteSession(sessionToken: string) {
+  await db.delete(sessions).where(eq(sessions.sessionToken, sessionToken));
+}
+
+export async function setSessionCookie(sessionToken: string, expiresAt: Date) {
+  const cookieStore = await cookies();
+
+  cookieStore.set(AUTH_SESSION_COOKIE_NAME, sessionToken, {
+    httpOnly: true,
+    sameSite: "lax",
+    secure: process.env.NODE_ENV === "production",
+    path: "/",
+    expires: expiresAt,
+  });
+}
+
+export async function clearSessionCookie() {
+  const cookieStore = await cookies();
+
+  cookieStore.set(AUTH_SESSION_COOKIE_NAME, "", {
+    httpOnly: true,
+    sameSite: "lax",
+    secure: process.env.NODE_ENV === "production",
+    path: "/",
+    expires: new Date(0),
+  });
+}

--- a/src/modules/i18n/dictionaries/ru/app.ts
+++ b/src/modules/i18n/dictionaries/ru/app.ts
@@ -13,7 +13,16 @@ export const app = {
   },
   login: {
     title: "Вход",
-    description: "Интерфейс авторизации появится на следующем этапе auth.",
+    description: "Войдите по email и паролю, чтобы перейти к текущему каркасу приложения.",
+    emailLabel: "Email",
+    passwordLabel: "Пароль",
+    submitLabel: "Войти",
+    loggedOutMessage: "Вы вышли из аккаунта.",
+    errors: {
+      invalidInput: "Введите корректный email и пароль.",
+      invalidCredentials: "Неверный email или пароль.",
+      unknown: "Не удалось выполнить вход. Попробуйте ещё раз.",
+    },
   },
   register: {
     title: "Регистрация",
@@ -33,6 +42,7 @@ export const app = {
   dashboard: {
     title: "Приложение",
     description: "Это только каркас защищённой зоны для будущих возможностей Wishka.",
+    logoutLabel: "Выйти",
   },
   reservations: {
     title: "Бронирования",

--- a/tests/unit/auth-login.test.ts
+++ b/tests/unit/auth-login.test.ts
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { findFirst, verifyPassword, createSession } = vi.hoisted(() => ({
+  findFirst: vi.fn(),
+  verifyPassword: vi.fn(),
+  createSession: vi.fn(),
+}));
+
+vi.mock("../../src/shared/db", () => ({
+  db: {
+    query: {
+      users: {
+        findFirst,
+      },
+    },
+  },
+}));
+
+vi.mock("../../src/modules/auth/server/password", () => ({
+  verifyPassword,
+}));
+
+vi.mock("../../src/modules/auth/server/session", () => ({
+  createSession,
+}));
+
+import { loginUser } from "../../src/modules/auth/server/login";
+import { validateLoginUserInput } from "../../src/modules/auth/server/login-input";
+
+describe("login user validation", () => {
+  it("rejects malformed credentials before querying the database", async () => {
+    expect(validateLoginUserInput({ email: "bad-email", password: "" })).toEqual({
+      status: "error",
+      code: "invalid-input",
+    });
+
+    await expect(loginUser({ email: "bad-email", password: "" })).resolves.toEqual({
+      status: "error",
+      code: "invalid-input",
+    });
+    expect(findFirst).not.toHaveBeenCalled();
+  });
+});
+
+describe("login user flow", () => {
+  beforeEach(() => {
+    findFirst.mockReset();
+    verifyPassword.mockReset();
+    createSession.mockReset();
+  });
+
+  it("returns a generic error when user credentials are invalid", async () => {
+    findFirst.mockResolvedValue({
+      id: "user-1",
+      passwordHash: "stored-hash",
+    });
+    verifyPassword.mockResolvedValue(false);
+
+    await expect(
+      loginUser({ email: "USER@example.com", password: "wrong-password" }),
+    ).resolves.toEqual({
+      status: "error",
+      code: "invalid-credentials",
+    });
+    expect(createSession).not.toHaveBeenCalled();
+  });
+
+  it("creates a session after successful credential verification", async () => {
+    const expiresAt = new Date("2026-05-01T00:00:00.000Z");
+
+    findFirst.mockResolvedValue({
+      id: "user-1",
+      passwordHash: "stored-hash",
+    });
+    verifyPassword.mockResolvedValue(true);
+    createSession.mockResolvedValue({
+      sessionToken: "session-token",
+      expiresAt,
+    });
+
+    await expect(
+      loginUser({ email: " USER@example.com ", password: "correct-password" }),
+    ).resolves.toEqual({
+      status: "success",
+      sessionToken: "session-token",
+      expiresAt,
+    });
+    expect(verifyPassword).toHaveBeenCalledWith("correct-password", "stored-hash");
+    expect(createSession).toHaveBeenCalledWith("user-1");
+  });
+});

--- a/tests/unit/auth-logout.test.ts
+++ b/tests/unit/auth-logout.test.ts
@@ -1,0 +1,27 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { deleteSession } = vi.hoisted(() => ({
+  deleteSession: vi.fn(),
+}));
+
+vi.mock("../../src/modules/auth/server/session", () => ({
+  deleteSession,
+}));
+
+import { logoutUser } from "../../src/modules/auth/server/logout";
+
+describe("logout user flow", () => {
+  beforeEach(() => {
+    deleteSession.mockReset();
+  });
+
+  it("does nothing when there is no current session token", async () => {
+    await expect(logoutUser(undefined)).resolves.toBeUndefined();
+    expect(deleteSession).not.toHaveBeenCalled();
+  });
+
+  it("removes the current session when a token is present", async () => {
+    await expect(logoutUser("session-token")).resolves.toBeUndefined();
+    expect(deleteSession).toHaveBeenCalledWith("session-token");
+  });
+});


### PR DESCRIPTION
Closes #22 

Create a minimal server-side session flow so users can sign in to the app shell and sign out cleanly before route guards land in a follow-up PR. Keep auth state in the `sessions` table plus an HTTP-only cookie to preserve a small server-first foundation without expanding into protected-route logic.

## What changed

- replaced the `/login` route skeleton with a working login form and server action
- added server-side login validation and login flow handling
- reused the existing auth helpers for:
  - email normalization
  - password verification
- added minimal session helpers for session creation and deletion
- created session records in the `sessions` table on successful login
- set an HTTP-only session cookie for authenticated state
- added logout handling that removes the current session and clears the cookie
- added a minimal logout action entry point from `/app`
- updated Russian UI strings for the login and logout flow
- documented the new auth flow foundation in the auth module docs
- updated the changelog for the new auth milestone progress

## How to verify

- open `/login`
- submit valid credentials for an existing user
- confirm the login succeeds and redirects to `/app`
- confirm a session record is created in the database
- confirm the session cookie is set as HTTP-only
- trigger logout from `/app`
- confirm the session record is removed
- confirm the cookie is cleared
- confirm the user is redirected to `/login?status=logged-out`
- submit invalid credentials
- confirm the page returns to `/login` with a predictable error state
- confirm credential errors do not reveal whether the email or password was incorrect

## Tests

- `npm install`
- `npm run typecheck`
- `npx vitest run tests/unit/auth-password.test.ts tests/unit/auth-register.test.ts tests/unit/auth-login.test.ts tests/unit/auth-logout.test.ts tests/unit/healthz.test.ts`
- `npm run build`

## Documentation

- updated `src/modules/auth/README.md`
- updated Russian auth-related app dictionary entries
- updated `CHANGELOG.md`