### PR TITLE
test(auth): expand milestone 2 coverage

### DIFF
--- a/tests/e2e/auth-guards.spec.ts
+++ b/tests/e2e/auth-guards.spec.ts
@@ -1,0 +1,24 @@
+import { expect, test } from "@playwright/test";
+
+test("login route renders the auth form", async ({ page }) => {
+  await page.goto("/login");
+
+  await expect(page.getByRole("heading", { name: "Вход" })).toBeVisible();
+  await expect(page.getByLabel("Email")).toBeVisible();
+  await expect(page.getByLabel("Пароль")).toBeVisible();
+  await expect(page.getByRole("button", { name: "Войти" })).toBeVisible();
+});
+
+test("unauthenticated user is redirected from /app to /login", async ({ page }) => {
+  await page.goto("/app");
+
+  await expect(page).toHaveURL(/\/login$/);
+  await expect(page.getByRole("heading", { name: "Вход" })).toBeVisible();
+});
+
+test("unauthenticated user is redirected from /app/reservations to /login", async ({ page }) => {
+  await page.goto("/app/reservations");
+
+  await expect(page).toHaveURL(/\/login$/);
+  await expect(page.getByRole("heading", { name: "Вход" })).toBeVisible();
+});

--- a/tests/unit/auth-current-user.test.ts
+++ b/tests/unit/auth-current-user.test.ts
@@ -70,6 +70,13 @@ describe("current auth helpers", () => {
     await expect(getCurrentSession()).resolves.toBeNull();
   });
 
+  it("treats expired sessions as unauthenticated", async () => {
+    mocks.cookieGet.mockReturnValue({ value: "expired-token" });
+    mocks.sessionFindFirst.mockResolvedValue(null);
+
+    await expect(getCurrentSession()).resolves.toBeNull();
+  });
+
   it("loads the current user from a valid session", async () => {
     mocks.cookieGet.mockReturnValue({ value: "valid-token" });
     mocks.sessionFindFirst.mockResolvedValue({
@@ -87,6 +94,19 @@ describe("current auth helpers", () => {
       id: "user-1",
       email: "user@example.com",
     });
+  });
+
+  it("returns null when the session exists but the user record is missing", async () => {
+    mocks.cookieGet.mockReturnValue({ value: "valid-token" });
+    mocks.sessionFindFirst.mockResolvedValue({
+      id: "session-1",
+      userId: "user-1",
+      sessionToken: "valid-token",
+      expiresAt: new Date("2026-05-01T00:00:00.000Z"),
+    });
+    mocks.userFindFirst.mockResolvedValue(undefined);
+
+    await expect(getCurrentUser()).resolves.toBeNull();
   });
 
   it("redirects to login when the current user is missing", async () => {

--- a/tests/unit/auth-login.test.ts
+++ b/tests/unit/auth-login.test.ts
@@ -65,6 +65,19 @@ describe("login user flow", () => {
     expect(createSession).not.toHaveBeenCalled();
   });
 
+  it("returns a generic error when the user does not exist", async () => {
+    findFirst.mockResolvedValue(undefined);
+
+    await expect(
+      loginUser({ email: "missing@example.com", password: "wrong-password" }),
+    ).resolves.toEqual({
+      status: "error",
+      code: "invalid-credentials",
+    });
+    expect(verifyPassword).not.toHaveBeenCalled();
+    expect(createSession).not.toHaveBeenCalled();
+  });
+
   it("creates a session after successful credential verification", async () => {
     const expiresAt = new Date("2026-05-01T00:00:00.000Z");
 

--- a/tests/unit/auth-register-flow.test.ts
+++ b/tests/unit/auth-register-flow.test.ts
@@ -1,0 +1,92 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { DatabaseError } from "pg";
+
+const mocks = vi.hoisted(() => ({
+  findFirst: vi.fn(),
+  insert: vi.fn(),
+  insertValues: vi.fn(),
+  hashPassword: vi.fn(),
+}));
+
+vi.mock("../../src/shared/db", () => ({
+  db: {
+    query: {
+      users: {
+        findFirst: mocks.findFirst,
+      },
+    },
+    insert: mocks.insert,
+  },
+}));
+
+vi.mock("../../src/modules/auth/server/password", () => ({
+  hashPassword: mocks.hashPassword,
+}));
+
+import { registerUser } from "../../src/modules/auth/server/register";
+
+describe("register user flow", () => {
+  beforeEach(() => {
+    mocks.findFirst.mockReset();
+    mocks.insert.mockReset();
+    mocks.insertValues.mockReset();
+    mocks.hashPassword.mockReset();
+
+    mocks.insert.mockReturnValue({
+      values: mocks.insertValues,
+    });
+  });
+
+  it("rejects invalid input before querying the database", async () => {
+    await expect(registerUser({ email: "bad-email", password: "short" })).resolves.toEqual({
+      status: "error",
+      code: "invalid-email",
+    });
+    expect(mocks.findFirst).not.toHaveBeenCalled();
+    expect(mocks.hashPassword).not.toHaveBeenCalled();
+  });
+
+  it("creates a user for valid new credentials", async () => {
+    mocks.findFirst.mockResolvedValue(undefined);
+    mocks.hashPassword.mockResolvedValue("hashed-password");
+    mocks.insertValues.mockResolvedValue(undefined);
+
+    await expect(
+      registerUser({ email: " User@Example.com ", password: "password123" }),
+    ).resolves.toEqual({ status: "success" });
+    expect(mocks.hashPassword).toHaveBeenCalledWith("password123");
+    expect(mocks.insertValues).toHaveBeenCalledWith({
+      email: "user@example.com",
+      passwordHash: "hashed-password",
+    });
+  });
+
+  it("returns duplicate email when the user already exists", async () => {
+    mocks.findFirst.mockResolvedValue({ id: "user-1" });
+
+    await expect(
+      registerUser({ email: "user@example.com", password: "password123" }),
+    ).resolves.toEqual({
+      status: "error",
+      code: "email-taken",
+    });
+    expect(mocks.hashPassword).not.toHaveBeenCalled();
+    expect(mocks.insert).not.toHaveBeenCalled();
+  });
+
+  it("maps unique email insert races to duplicate email", async () => {
+    const error = new DatabaseError("duplicate key", 0, "error");
+    error.code = "23505";
+
+    mocks.findFirst.mockResolvedValue(undefined);
+    mocks.hashPassword.mockResolvedValue("hashed-password");
+    mocks.insertValues.mockRejectedValue(error);
+
+    await expect(
+      registerUser({ email: "user@example.com", password: "password123" }),
+    ).resolves.toEqual({
+      status: "error",
+      code: "email-taken",
+    });
+  });
+});

--- a/tests/unit/auth-session.test.ts
+++ b/tests/unit/auth-session.test.ts
@@ -1,0 +1,102 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  cookieSet: vi.fn(),
+  insert: vi.fn(),
+  insertValues: vi.fn(),
+  deleteSession: vi.fn(),
+  deleteWhere: vi.fn(),
+  randomBytes: vi.fn(),
+}));
+
+vi.mock("node:crypto", () => ({
+  randomBytes: mocks.randomBytes,
+}));
+
+vi.mock("next/headers", () => ({
+  cookies: vi.fn(async () => ({
+    set: mocks.cookieSet,
+  })),
+}));
+
+vi.mock("../../src/shared/db", () => ({
+  db: {
+    insert: mocks.insert,
+    delete: mocks.deleteSession,
+  },
+}));
+
+import {
+  AUTH_SESSION_COOKIE_NAME,
+  clearSessionCookie,
+  createSession,
+  deleteSession,
+  setSessionCookie,
+} from "../../src/modules/auth/server/session";
+
+describe("auth session helpers", () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+    mocks.cookieSet.mockReset();
+    mocks.insert.mockReset();
+    mocks.insertValues.mockReset();
+    mocks.deleteSession.mockReset();
+    mocks.deleteWhere.mockReset();
+    mocks.randomBytes.mockReset();
+
+    mocks.insert.mockReturnValue({
+      values: mocks.insertValues,
+    });
+    mocks.deleteSession.mockReturnValue({
+      where: mocks.deleteWhere,
+    });
+    mocks.randomBytes.mockReturnValue(Buffer.alloc(32, 1));
+  });
+
+  it("creates a persistent server-side session record", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-11T00:00:00.000Z"));
+    mocks.insertValues.mockResolvedValue(undefined);
+
+    const result = await createSession("user-1");
+
+    expect(result.sessionToken).toBeTypeOf("string");
+    expect(result.expiresAt).toEqual(new Date("2026-05-11T00:00:00.000Z"));
+    expect(mocks.insertValues).toHaveBeenCalledWith({
+      userId: "user-1",
+      sessionToken: result.sessionToken,
+      expiresAt: new Date("2026-05-11T00:00:00.000Z"),
+    });
+  });
+
+  it("deletes a session by token", async () => {
+    mocks.deleteWhere.mockResolvedValue(undefined);
+
+    await expect(deleteSession("session-token")).resolves.toBeUndefined();
+    expect(mocks.deleteWhere).toHaveBeenCalled();
+  });
+
+  it("sets the auth cookie for a valid session", async () => {
+    const expiresAt = new Date("2026-05-01T00:00:00.000Z");
+
+    await expect(setSessionCookie("session-token", expiresAt)).resolves.toBeUndefined();
+    expect(mocks.cookieSet).toHaveBeenCalledWith(AUTH_SESSION_COOKIE_NAME, "session-token", {
+      httpOnly: true,
+      sameSite: "lax",
+      secure: false,
+      path: "/",
+      expires: expiresAt,
+    });
+  });
+
+  it("clears the auth cookie on logout", async () => {
+    await expect(clearSessionCookie()).resolves.toBeUndefined();
+    expect(mocks.cookieSet).toHaveBeenCalledWith(AUTH_SESSION_COOKIE_NAME, "", {
+      httpOnly: true,
+      sameSite: "lax",
+      secure: false,
+      path: "/",
+      expires: new Date(0),
+    });
+  });
+});


### PR DESCRIPTION
Closes #24 

Cover the implemented auth flows with focused unit and minimal e2e tests so registration, sessions, login/logout, and route guards are protected before Milestone 3 work starts. Keep the suite fast and maintainable by concentrating browser tests on the unauthenticated guard journey while exercising server-side auth logic through narrow integration-like unit tests.

## What changed

- added coverage for registration flow scenarios:
  - invalid input
  - successful registration
  - duplicate email
  - duplicate email on unique-constraint race
- expanded login coverage for:
  - invalid input
  - missing user
  - wrong password
  - successful login with session creation
- added session helper coverage for:
  - session creation
  - session deletion
  - cookie set
  - cookie clear
- expanded current-session and current-user coverage for:
  - missing cookie
  - invalid session
  - expired session
  - valid session and valid user
  - valid session with missing user
  - redirect behavior in `requireCurrentUser()`
- added minimal e2e coverage for:
  - redirect from `/app` to `/login` when unauthenticated
  - redirect from `/app/reservations` to `/login` when unauthenticated
  - rendering of the login form
- kept the coverage focused on existing Milestone 2 behavior without introducing new auth features

## How to verify

- run the unit test suite for auth-related behavior
- run the minimal auth e2e checks
- confirm unauthenticated access to `/app` and `/app/reservations` redirects to `/login`
- confirm the login page still renders correctly
- confirm the existing auth flows continue to build and typecheck successfully

## Tests

- `npm run typecheck`
- `npx vitest run tests/unit/auth-password.test.ts tests/unit/auth-register.test.ts tests/unit/auth-register-flow.test.ts tests/unit/auth-login.test.ts tests/unit/auth-logout.test.ts tests/unit/auth-session.test.ts tests/unit/auth-current-user.test.ts tests/unit/auth-route-guards.test.ts tests/unit/healthz.test.ts`
- `npx playwright test tests/e2e/auth-guards.spec.ts tests/e2e/app-shell.spec.ts`
- `npm run build`

## Documentation

- no behavior or architecture documentation changes required