### PR TITLE
feat(wishlist): add owner wishlist bootstrap flow

### DIFF
--- a/src/app/app/page.tsx
+++ b/src/app/app/page.tsx
@@ -2,13 +2,16 @@ import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 import { requireCurrentUser } from "@/modules/auth/server/current-user";
 import { getTranslations } from "@/modules/i18n";
+import { getOrCreateCurrentWishlist } from "@/modules/wishlist/server/current-wishlist";
 import { PageShell } from "@/shared/ui/page-shell";
 
 const common = getTranslations("common");
 const messages = getTranslations("app");
 
 export default async function AppPage() {
-  await requireCurrentUser();
+  const user = await requireCurrentUser();
+
+  await getOrCreateCurrentWishlist(user.id);
 
   return (
     <PageShell

--- a/src/modules/wishlist/index.ts
+++ b/src/modules/wishlist/index.ts
@@ -1,1 +1,5 @@
 export { wishlistItems, wishlists } from "@/modules/wishlist/db/schema";
+export {
+  type CurrentWishlist,
+  getOrCreateCurrentWishlist,
+} from "@/modules/wishlist/server/current-wishlist";

--- a/src/modules/wishlist/server/current-wishlist.ts
+++ b/src/modules/wishlist/server/current-wishlist.ts
@@ -1,0 +1,79 @@
+import { and, asc, eq } from "drizzle-orm";
+import { wishlists } from "@/modules/wishlist/db/schema";
+
+export type CurrentWishlist = {
+  id: string;
+  userId: string;
+  isActive: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+export async function getOrCreateCurrentWishlist(userId: string): Promise<CurrentWishlist> {
+  const currentWishlist = await findCurrentWishlist(userId);
+
+  if (currentWishlist) {
+    return currentWishlist;
+  }
+
+  const db = await getDb();
+  const [createdWishlist] = await db
+    .insert(wishlists)
+    .values({
+      userId,
+      isActive: true,
+    })
+    .returning({
+      id: wishlists.id,
+      userId: wishlists.userId,
+      isActive: wishlists.isActive,
+      createdAt: wishlists.createdAt,
+      updatedAt: wishlists.updatedAt,
+    });
+
+  if (!createdWishlist) {
+    throw new Error("Failed to create current wishlist.");
+  }
+
+  return createdWishlist;
+}
+
+async function findCurrentWishlist(userId: string): Promise<CurrentWishlist | null> {
+  const db = await getDb();
+
+  const activeWishlist = await db.query.wishlists.findFirst({
+    columns: {
+      id: true,
+      userId: true,
+      isActive: true,
+      createdAt: true,
+      updatedAt: true,
+    },
+    where: and(eq(wishlists.userId, userId), eq(wishlists.isActive, true)),
+    orderBy: [asc(wishlists.createdAt)],
+  });
+
+  if (activeWishlist) {
+    return activeWishlist;
+  }
+
+  const existingWishlist = await db.query.wishlists.findFirst({
+    columns: {
+      id: true,
+      userId: true,
+      isActive: true,
+      createdAt: true,
+      updatedAt: true,
+    },
+    where: eq(wishlists.userId, userId),
+    orderBy: [asc(wishlists.createdAt)],
+  });
+
+  return existingWishlist ?? null;
+}
+
+async function getDb() {
+  const { db } = await import("@/shared/db");
+
+  return db;
+}

--- a/tests/unit/wishlist-app-bootstrap.test.ts
+++ b/tests/unit/wishlist-app-bootstrap.test.ts
@@ -14,11 +14,12 @@ vi.mock("../../src/modules/wishlist/server/current-wishlist", () => ({
   getOrCreateCurrentWishlist: mocks.getOrCreateCurrentWishlist,
 }));
 
-describe("protected owner routes", () => {
+describe("owner app wishlist bootstrap", () => {
   beforeEach(() => {
     Object.assign(globalThis, { React });
     mocks.requireCurrentUser.mockReset();
     mocks.getOrCreateCurrentWishlist.mockReset();
+
     mocks.requireCurrentUser.mockResolvedValue({
       id: "user-1",
       email: "user@example.com",
@@ -32,19 +33,12 @@ describe("protected owner routes", () => {
     });
   });
 
-  it("guards /app on the server", async () => {
+  it("bootstraps the current wishlist for the authenticated owner on /app", async () => {
     const { default: AppPage } = await import("../../src/app/app/page");
 
     await AppPage();
 
     expect(mocks.requireCurrentUser).toHaveBeenCalled();
-  });
-
-  it("guards /app/reservations on the server", async () => {
-    const { default: ReservationsPage } = await import("../../src/app/app/reservations/page");
-
-    await ReservationsPage();
-
-    expect(mocks.requireCurrentUser).toHaveBeenCalled();
+    expect(mocks.getOrCreateCurrentWishlist).toHaveBeenCalledWith("user-1");
   });
 });

--- a/tests/unit/wishlist-current-wishlist.test.ts
+++ b/tests/unit/wishlist-current-wishlist.test.ts
@@ -1,0 +1,106 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  findFirst: vi.fn(),
+  insert: vi.fn(),
+  insertValues: vi.fn(),
+  insertReturning: vi.fn(),
+}));
+
+vi.mock("../../src/shared/db", () => ({
+  db: {
+    query: {
+      wishlists: {
+        findFirst: mocks.findFirst,
+      },
+    },
+    insert: mocks.insert,
+  },
+}));
+
+import { getOrCreateCurrentWishlist } from "../../src/modules/wishlist/server/current-wishlist";
+
+describe("current owner wishlist bootstrap", () => {
+  beforeEach(() => {
+    mocks.findFirst.mockReset();
+    mocks.insert.mockReset();
+    mocks.insertValues.mockReset();
+    mocks.insertReturning.mockReset();
+
+    mocks.insert.mockReturnValue({
+      values: mocks.insertValues,
+    });
+    mocks.insertValues.mockReturnValue({
+      returning: mocks.insertReturning,
+    });
+  });
+
+  it("returns the current active wishlist when it exists", async () => {
+    const wishlist = {
+      id: "wishlist-1",
+      userId: "user-1",
+      isActive: true,
+      createdAt: new Date("2026-04-11T00:00:00.000Z"),
+      updatedAt: new Date("2026-04-11T00:00:00.000Z"),
+    };
+
+    mocks.findFirst.mockResolvedValueOnce(wishlist);
+
+    await expect(getOrCreateCurrentWishlist("user-1")).resolves.toEqual(wishlist);
+    expect(mocks.insert).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the oldest existing wishlist when no active wishlist exists", async () => {
+    const wishlist = {
+      id: "wishlist-1",
+      userId: "user-1",
+      isActive: false,
+      createdAt: new Date("2026-04-11T00:00:00.000Z"),
+      updatedAt: new Date("2026-04-11T00:00:00.000Z"),
+    };
+
+    mocks.findFirst.mockResolvedValueOnce(undefined).mockResolvedValueOnce(wishlist);
+
+    await expect(getOrCreateCurrentWishlist("user-1")).resolves.toEqual(wishlist);
+    expect(mocks.insert).not.toHaveBeenCalled();
+  });
+
+  it("creates a wishlist when the owner does not have one yet", async () => {
+    const wishlist = {
+      id: "wishlist-1",
+      userId: "user-1",
+      isActive: true,
+      createdAt: new Date("2026-04-11T00:00:00.000Z"),
+      updatedAt: new Date("2026-04-11T00:00:00.000Z"),
+    };
+
+    mocks.findFirst.mockResolvedValueOnce(undefined).mockResolvedValueOnce(undefined);
+    mocks.insertReturning.mockResolvedValue([wishlist]);
+
+    await expect(getOrCreateCurrentWishlist("user-1")).resolves.toEqual(wishlist);
+    expect(mocks.insertValues).toHaveBeenCalledWith({
+      userId: "user-1",
+      isActive: true,
+    });
+  });
+
+  it("does not create duplicates on repeated reads after bootstrap", async () => {
+    const wishlist = {
+      id: "wishlist-1",
+      userId: "user-1",
+      isActive: true,
+      createdAt: new Date("2026-04-11T00:00:00.000Z"),
+      updatedAt: new Date("2026-04-11T00:00:00.000Z"),
+    };
+
+    mocks.findFirst
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce(wishlist);
+    mocks.insertReturning.mockResolvedValue([wishlist]);
+
+    await expect(getOrCreateCurrentWishlist("user-1")).resolves.toEqual(wishlist);
+    await expect(getOrCreateCurrentWishlist("user-1")).resolves.toEqual(wishlist);
+    expect(mocks.insert).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
Closes #33 

Bootstrap a current owner wishlist on the server so authenticated users can always land on `/app` with one predictable wishlist in the v1 UI. Keep the flow minimal by reusing the auth guard foundation and choosing a stable current-wishlist rule without expanding into dashboard or item management behavior yet.

## What changed

- added a server-side current wishlist bootstrap helper in the wishlist module
- made `/app` resolve the authenticated owner’s current wishlist after auth guard checks
- implemented a stable current-wishlist selection rule:
  - prefer the active wishlist
  - if multiple active wishlists exist, use the earliest one
  - if no active wishlist exists, fall back to the earliest existing wishlist
  - if no wishlist exists, create one
- added automatic wishlist creation for authenticated users who do not have a wishlist yet
- kept the flow server-side and limited to bootstrap behavior only
- updated wishlist module exports for the new current-wishlist helper

## How to verify

- log in with an authenticated user and open `/app`
- confirm the route resolves successfully through the existing auth guard
- confirm that a wishlist is created automatically if the user does not have one yet
- confirm that revisiting `/app` does not create duplicate wishlists during normal repeated access
- confirm that an existing active wishlist is reused
- confirm that the implementation does not add dashboard data loading or item CRUD behavior yet

## Tests

- `npm run typecheck`
- `npx vitest run tests/unit/wishlist-current-wishlist.test.ts tests/unit/wishlist-app-bootstrap.test.ts tests/unit/auth-current-user.test.ts tests/unit/auth-route-guards.test.ts`
- `npm run build`

## Documentation

- no additional product or process documentation changes required for this PR