### PR TITLE
feat(wishlist): add item data access foundation

### DIFF
--- a/src/modules/wishlist/index.ts
+++ b/src/modules/wishlist/index.ts
@@ -3,3 +3,10 @@ export {
   type CurrentWishlist,
   getOrCreateCurrentWishlist,
 } from "@/modules/wishlist/server/current-wishlist";
+export {
+  type WishlistItemRecord,
+  type WishlistWithItems,
+  getCurrentWishlistWithItems,
+  getWishlistWithItems,
+  listWishlistItems,
+} from "@/modules/wishlist/server/items";

--- a/src/modules/wishlist/server/items.ts
+++ b/src/modules/wishlist/server/items.ts
@@ -1,0 +1,82 @@
+import { asc, eq } from "drizzle-orm";
+import { wishlistItems, wishlists } from "@/modules/wishlist/db/schema";
+import {
+  type CurrentWishlist,
+  getOrCreateCurrentWishlist,
+} from "@/modules/wishlist/server/current-wishlist";
+
+export type WishlistItemRecord = {
+  id: string;
+  wishlistId: string;
+  title: string;
+  url: string | null;
+  note: string | null;
+  price: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+export type WishlistWithItems = CurrentWishlist & {
+  items: WishlistItemRecord[];
+};
+
+export async function listWishlistItems(wishlistId: string): Promise<WishlistItemRecord[]> {
+  const db = await getDb();
+
+  return db.query.wishlistItems.findMany({
+    columns: {
+      id: true,
+      wishlistId: true,
+      title: true,
+      url: true,
+      note: true,
+      price: true,
+      createdAt: true,
+      updatedAt: true,
+    },
+    where: eq(wishlistItems.wishlistId, wishlistId),
+    orderBy: [asc(wishlistItems.createdAt), asc(wishlistItems.id)],
+  });
+}
+
+export async function getWishlistWithItems(wishlistId: string): Promise<WishlistWithItems | null> {
+  const db = await getDb();
+
+  const wishlist = await db.query.wishlists.findFirst({
+    columns: {
+      id: true,
+      userId: true,
+      isActive: true,
+      createdAt: true,
+      updatedAt: true,
+    },
+    where: eq(wishlists.id, wishlistId),
+  });
+
+  if (!wishlist) {
+    return null;
+  }
+
+  const items = await listWishlistItems(wishlist.id);
+
+  return {
+    ...wishlist,
+    items,
+  };
+}
+
+export async function getCurrentWishlistWithItems(userId: string): Promise<WishlistWithItems> {
+  const wishlist = await getOrCreateCurrentWishlist(userId);
+  const items = await listWishlistItems(wishlist.id);
+
+  return {
+    ...wishlist,
+    items,
+  };
+}
+
+async function getDb() {
+  const { db } = await import("@/shared/db");
+
+  return db;
+}

--- a/tests/unit/wishlist-items.test.ts
+++ b/tests/unit/wishlist-items.test.ts
@@ -1,0 +1,126 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  findWishlistItems: vi.fn(),
+  findWishlists: vi.fn(),
+  getOrCreateCurrentWishlist: vi.fn(),
+}));
+
+vi.mock("../../src/shared/db", () => ({
+  db: {
+    query: {
+      wishlistItems: {
+        findMany: mocks.findWishlistItems,
+      },
+      wishlists: {
+        findFirst: mocks.findWishlists,
+      },
+    },
+  },
+}));
+
+vi.mock("../../src/modules/wishlist/server/current-wishlist", () => ({
+  getOrCreateCurrentWishlist: mocks.getOrCreateCurrentWishlist,
+}));
+
+import {
+  getCurrentWishlistWithItems,
+  getWishlistWithItems,
+  listWishlistItems,
+} from "../../src/modules/wishlist/server/items";
+
+describe("wishlist item data access", () => {
+  beforeEach(() => {
+    mocks.findWishlistItems.mockReset();
+    mocks.findWishlists.mockReset();
+    mocks.getOrCreateCurrentWishlist.mockReset();
+  });
+
+  it("lists wishlist items with a predictable order", async () => {
+    const items = [
+      {
+        id: "item-1",
+        wishlistId: "wishlist-1",
+        title: "Item 1",
+        url: null,
+        note: null,
+        price: null,
+        createdAt: new Date("2026-04-11T00:00:00.000Z"),
+        updatedAt: new Date("2026-04-11T00:00:00.000Z"),
+      },
+    ];
+
+    mocks.findWishlistItems.mockResolvedValue(items);
+
+    await expect(listWishlistItems("wishlist-1")).resolves.toEqual(items);
+    expect(mocks.findWishlistItems).toHaveBeenCalledOnce();
+  });
+
+  it("loads a wishlist together with its items", async () => {
+    const wishlist = {
+      id: "wishlist-1",
+      userId: "user-1",
+      isActive: true,
+      createdAt: new Date("2026-04-11T00:00:00.000Z"),
+      updatedAt: new Date("2026-04-11T00:00:00.000Z"),
+    };
+    const items = [
+      {
+        id: "item-1",
+        wishlistId: "wishlist-1",
+        title: "Item 1",
+        url: null,
+        note: null,
+        price: null,
+        createdAt: new Date("2026-04-11T00:00:00.000Z"),
+        updatedAt: new Date("2026-04-11T00:00:00.000Z"),
+      },
+    ];
+
+    mocks.findWishlists.mockResolvedValue(wishlist);
+    mocks.findWishlistItems.mockResolvedValue(items);
+
+    await expect(getWishlistWithItems("wishlist-1")).resolves.toEqual({
+      ...wishlist,
+      items,
+    });
+  });
+
+  it("returns null when the wishlist does not exist", async () => {
+    mocks.findWishlists.mockResolvedValue(undefined);
+
+    await expect(getWishlistWithItems("wishlist-1")).resolves.toBeNull();
+    expect(mocks.findWishlistItems).not.toHaveBeenCalled();
+  });
+
+  it("loads the current owner wishlist together with its items", async () => {
+    const wishlist = {
+      id: "wishlist-1",
+      userId: "user-1",
+      isActive: true,
+      createdAt: new Date("2026-04-11T00:00:00.000Z"),
+      updatedAt: new Date("2026-04-11T00:00:00.000Z"),
+    };
+    const items = [
+      {
+        id: "item-1",
+        wishlistId: "wishlist-1",
+        title: "Item 1",
+        url: null,
+        note: null,
+        price: null,
+        createdAt: new Date("2026-04-11T00:00:00.000Z"),
+        updatedAt: new Date("2026-04-11T00:00:00.000Z"),
+      },
+    ];
+
+    mocks.getOrCreateCurrentWishlist.mockResolvedValue(wishlist);
+    mocks.findWishlistItems.mockResolvedValue(items);
+
+    await expect(getCurrentWishlistWithItems("user-1")).resolves.toEqual({
+      ...wishlist,
+      items,
+    });
+    expect(mocks.getOrCreateCurrentWishlist).toHaveBeenCalledWith("user-1");
+  });
+});


### PR DESCRIPTION
Closes #34 

Add minimal server-side wishlist read helpers so upcoming Milestone 3 PRs can load a current wishlist and its items without spreading raw queries across app routes. Keep the foundation small and read-focused by exposing predictable item ordering and wishlist-with-items helpers without stepping into CRUD or dashboard UI behavior yet.

## What changed

- added a server-side item data access layer inside the wishlist module
- added `listWishlistItems(wishlistId)` to read items for a specific wishlist
- added `getWishlistWithItems(wishlistId)` to load a wishlist together with its items
- added `getCurrentWishlistWithItems(userId)` to bridge the existing owner bootstrap flow with item reads
- defined predictable item ordering by `createdAt`, then `id`
- updated wishlist module exports so the next milestone PRs can reuse the new read helpers

## How to verify

- inspect `src/modules/wishlist/server/items.ts`
- confirm that the new helpers live inside the wishlist module
- confirm that `listWishlistItems(wishlistId)` returns items in a stable order
- confirm that `getWishlistWithItems(wishlistId)` returns `null` when the wishlist does not exist
- confirm that `getCurrentWishlistWithItems(userId)` composes with the existing current wishlist bootstrap flow
- confirm that no app route was changed to include raw wishlist item queries

## Tests

- `npm run typecheck`
- `npx vitest run tests/unit/wishlist-current-wishlist.test.ts tests/unit/wishlist-items.test.ts tests/unit/wishlist-app-bootstrap.test.ts`
- `npm run build`

## Documentation

- no additional product or process documentation changes required for this PR