### PR TITLE
feat(wishlist): load owner dashboard data on app

### DIFF
--- a/src/app/app/page.tsx
+++ b/src/app/app/page.tsx
@@ -2,7 +2,7 @@ import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 import { requireCurrentUser } from "@/modules/auth/server/current-user";
 import { getTranslations } from "@/modules/i18n";
-import { getOrCreateCurrentWishlist } from "@/modules/wishlist/server/current-wishlist";
+import { getCurrentWishlistWithItems } from "@/modules/wishlist/server/items";
 import { PageShell } from "@/shared/ui/page-shell";
 
 const common = getTranslations("common");
@@ -10,8 +10,7 @@ const messages = getTranslations("app");
 
 export default async function AppPage() {
   const user = await requireCurrentUser();
-
-  await getOrCreateCurrentWishlist(user.id);
+  const wishlist = await getCurrentWishlistWithItems(user.id);
 
   return (
     <PageShell
@@ -19,11 +18,89 @@ export default async function AppPage() {
       title={messages.dashboard.title}
       description={messages.dashboard.description}
     >
-      <form action={logoutAction}>
-        <button type="submit" className="ui-button">
-          {messages.dashboard.logoutLabel}
-        </button>
-      </form>
+      <div className="space-y-8">
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+          <div className="grid gap-3">
+            <p className="ui-note">{messages.dashboard.summaryLabel}</p>
+            <div
+              className="ui-surface p-5"
+              style={{ background: "var(--color-bg-subtle)" }}
+            >
+              <dl className="grid gap-3 sm:grid-cols-2">
+                <div>
+                  <dt className="ui-note">ID</dt>
+                  <dd className="mt-1 break-all font-medium text-[color:var(--color-text-strong)]">
+                    {wishlist.id}
+                  </dd>
+                </div>
+                <div>
+                  <dt className="ui-note">{messages.dashboard.itemCountLabel}</dt>
+                  <dd className="mt-1 font-medium text-[color:var(--color-text-strong)]">
+                    {wishlist.items.length}
+                  </dd>
+                </div>
+              </dl>
+            </div>
+          </div>
+          <form action={logoutAction}>
+            <button type="submit" className="ui-button">
+              {messages.dashboard.logoutLabel}
+            </button>
+          </form>
+        </div>
+
+        {wishlist.items.length === 0 ? (
+          <section className="ui-surface p-6">
+            <h2 className="text-lg font-semibold text-[color:var(--color-text-strong)]">
+              {messages.dashboard.emptyTitle}
+            </h2>
+            <p className="mt-3 text-[color:var(--color-text-base)]">
+              {messages.dashboard.emptyDescription}
+            </p>
+          </section>
+        ) : (
+          <section className="space-y-4">
+            <h2 className="text-lg font-semibold text-[color:var(--color-text-strong)]">
+              {messages.dashboard.itemsTitle}
+            </h2>
+            <ul className="space-y-4">
+              {wishlist.items.map((item) => (
+                <li key={item.id} className="ui-surface p-6">
+                  <div className="space-y-3">
+                    <h3 className="text-base font-semibold text-[color:var(--color-text-strong)]">
+                      {item.title}
+                    </h3>
+                    {item.url ? (
+                      <p className="text-sm text-[color:var(--color-text-base)] break-all">
+                        <span className="font-medium text-[color:var(--color-text-strong)]">
+                          {messages.dashboard.itemFields.url}: 
+                        </span>
+                        {item.url}
+                      </p>
+                    ) : null}
+                    {item.note ? (
+                      <p className="text-sm text-[color:var(--color-text-base)]">
+                        <span className="font-medium text-[color:var(--color-text-strong)]">
+                          {messages.dashboard.itemFields.note}: 
+                        </span>
+                        {item.note}
+                      </p>
+                    ) : null}
+                    {item.price ? (
+                      <p className="text-sm text-[color:var(--color-text-base)]">
+                        <span className="font-medium text-[color:var(--color-text-strong)]">
+                          {messages.dashboard.itemFields.price}: 
+                        </span>
+                        {item.price}
+                      </p>
+                    ) : null}
+                  </div>
+                </li>
+              ))}
+            </ul>
+          </section>
+        )}
+      </div>
     </PageShell>
   );
 }

--- a/src/modules/i18n/dictionaries/ru/app.ts
+++ b/src/modules/i18n/dictionaries/ru/app.ts
@@ -40,9 +40,19 @@ export const app = {
     },
   },
   dashboard: {
-    title: "Приложение",
-    description: "Это только каркас защищённой зоны для будущих возможностей Wishka.",
+    title: "Мой вишлист",
+    description: "Здесь собран ваш текущий вишлист и его предметы для будущего управления.",
     logoutLabel: "Выйти",
+    summaryLabel: "Текущий вишлист",
+    itemCountLabel: "Количество желаний",
+    emptyTitle: "Вишлист пока пуст",
+    emptyDescription: "Следующим шагом сюда можно будет добавить первое желание.",
+    itemsTitle: "Желания",
+    itemFields: {
+      url: "Ссылка",
+      note: "Заметка",
+      price: "Цена",
+    },
   },
   reservations: {
     title: "Бронирования",

--- a/src/modules/wishlist/index.ts
+++ b/src/modules/wishlist/index.ts
@@ -3,3 +3,10 @@ export {
   type CurrentWishlist,
   getOrCreateCurrentWishlist,
 } from "@/modules/wishlist/server/current-wishlist";
+export {
+  type WishlistItemRecord,
+  type WishlistWithItems,
+  getCurrentWishlistWithItems,
+  getWishlistWithItems,
+  listWishlistItems,
+} from "@/modules/wishlist/server/items";

--- a/src/modules/wishlist/server/items.ts
+++ b/src/modules/wishlist/server/items.ts
@@ -1,0 +1,82 @@
+import { asc, eq } from "drizzle-orm";
+import { wishlistItems, wishlists } from "@/modules/wishlist/db/schema";
+import {
+  type CurrentWishlist,
+  getOrCreateCurrentWishlist,
+} from "@/modules/wishlist/server/current-wishlist";
+
+export type WishlistItemRecord = {
+  id: string;
+  wishlistId: string;
+  title: string;
+  url: string | null;
+  note: string | null;
+  price: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+export type WishlistWithItems = CurrentWishlist & {
+  items: WishlistItemRecord[];
+};
+
+export async function listWishlistItems(wishlistId: string): Promise<WishlistItemRecord[]> {
+  const db = await getDb();
+
+  return db.query.wishlistItems.findMany({
+    columns: {
+      id: true,
+      wishlistId: true,
+      title: true,
+      url: true,
+      note: true,
+      price: true,
+      createdAt: true,
+      updatedAt: true,
+    },
+    where: eq(wishlistItems.wishlistId, wishlistId),
+    orderBy: [asc(wishlistItems.createdAt), asc(wishlistItems.id)],
+  });
+}
+
+export async function getWishlistWithItems(wishlistId: string): Promise<WishlistWithItems | null> {
+  const db = await getDb();
+
+  const wishlist = await db.query.wishlists.findFirst({
+    columns: {
+      id: true,
+      userId: true,
+      isActive: true,
+      createdAt: true,
+      updatedAt: true,
+    },
+    where: eq(wishlists.id, wishlistId),
+  });
+
+  if (!wishlist) {
+    return null;
+  }
+
+  const items = await listWishlistItems(wishlist.id);
+
+  return {
+    ...wishlist,
+    items,
+  };
+}
+
+export async function getCurrentWishlistWithItems(userId: string): Promise<WishlistWithItems> {
+  const wishlist = await getOrCreateCurrentWishlist(userId);
+  const items = await listWishlistItems(wishlist.id);
+
+  return {
+    ...wishlist,
+    items,
+  };
+}
+
+async function getDb() {
+  const { db } = await import("@/shared/db");
+
+  return db;
+}

--- a/tests/unit/wishlist-app-bootstrap.test.ts
+++ b/tests/unit/wishlist-app-bootstrap.test.ts
@@ -1,44 +1,88 @@
 import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   requireCurrentUser: vi.fn(),
-  getOrCreateCurrentWishlist: vi.fn(),
+  getCurrentWishlistWithItems: vi.fn(),
 }));
 
 vi.mock("../../src/modules/auth/server/current-user", () => ({
   requireCurrentUser: mocks.requireCurrentUser,
 }));
 
-vi.mock("../../src/modules/wishlist/server/current-wishlist", () => ({
-  getOrCreateCurrentWishlist: mocks.getOrCreateCurrentWishlist,
+vi.mock("../../src/modules/wishlist/server/items", () => ({
+  getCurrentWishlistWithItems: mocks.getCurrentWishlistWithItems,
 }));
 
 describe("owner app wishlist bootstrap", () => {
   beforeEach(() => {
     Object.assign(globalThis, { React });
     mocks.requireCurrentUser.mockReset();
-    mocks.getOrCreateCurrentWishlist.mockReset();
+    mocks.getCurrentWishlistWithItems.mockReset();
 
     mocks.requireCurrentUser.mockResolvedValue({
       id: "user-1",
       email: "user@example.com",
     });
-    mocks.getOrCreateCurrentWishlist.mockResolvedValue({
+    mocks.getCurrentWishlistWithItems.mockResolvedValue({
       id: "wishlist-1",
       userId: "user-1",
       isActive: true,
       createdAt: new Date("2026-04-11T00:00:00.000Z"),
       updatedAt: new Date("2026-04-11T00:00:00.000Z"),
+      items: [],
     });
   });
 
-  it("bootstraps the current wishlist for the authenticated owner on /app", async () => {
+  it("loads the current wishlist for the authenticated owner on /app", async () => {
     const { default: AppPage } = await import("../../src/app/app/page");
 
     await AppPage();
 
     expect(mocks.requireCurrentUser).toHaveBeenCalled();
-    expect(mocks.getOrCreateCurrentWishlist).toHaveBeenCalledWith("user-1");
+    expect(mocks.getCurrentWishlistWithItems).toHaveBeenCalledWith("user-1");
+  });
+
+  it("renders an empty state when the wishlist has no items", async () => {
+    const { default: AppPage } = await import("../../src/app/app/page");
+
+    const page = await AppPage();
+    const html = renderToStaticMarkup(page);
+
+    expect(html).toContain("Вишлист пока пуст");
+    expect(html).toContain("Количество желаний");
+  });
+
+  it("renders wishlist items when they exist", async () => {
+    mocks.getCurrentWishlistWithItems.mockResolvedValue({
+      id: "wishlist-1",
+      userId: "user-1",
+      isActive: true,
+      createdAt: new Date("2026-04-11T00:00:00.000Z"),
+      updatedAt: new Date("2026-04-11T00:00:00.000Z"),
+      items: [
+        {
+          id: "item-1",
+          wishlistId: "wishlist-1",
+          title: "Наушники",
+          url: "https://example.com/item",
+          note: "Нужны беспроводные",
+          price: "9990.00",
+          createdAt: new Date("2026-04-11T00:00:00.000Z"),
+          updatedAt: new Date("2026-04-11T00:00:00.000Z"),
+        },
+      ],
+    });
+
+    const { default: AppPage } = await import("../../src/app/app/page");
+
+    const page = await AppPage();
+    const html = renderToStaticMarkup(page);
+
+    expect(html).toContain("Наушники");
+    expect(html).toContain("https://example.com/item");
+    expect(html).toContain("Нужны беспроводные");
+    expect(html).toContain("9990.00");
   });
 });

--- a/tests/unit/wishlist-items.test.ts
+++ b/tests/unit/wishlist-items.test.ts
@@ -1,0 +1,126 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  findWishlistItems: vi.fn(),
+  findWishlists: vi.fn(),
+  getOrCreateCurrentWishlist: vi.fn(),
+}));
+
+vi.mock("../../src/shared/db", () => ({
+  db: {
+    query: {
+      wishlistItems: {
+        findMany: mocks.findWishlistItems,
+      },
+      wishlists: {
+        findFirst: mocks.findWishlists,
+      },
+    },
+  },
+}));
+
+vi.mock("../../src/modules/wishlist/server/current-wishlist", () => ({
+  getOrCreateCurrentWishlist: mocks.getOrCreateCurrentWishlist,
+}));
+
+import {
+  getCurrentWishlistWithItems,
+  getWishlistWithItems,
+  listWishlistItems,
+} from "../../src/modules/wishlist/server/items";
+
+describe("wishlist item data access", () => {
+  beforeEach(() => {
+    mocks.findWishlistItems.mockReset();
+    mocks.findWishlists.mockReset();
+    mocks.getOrCreateCurrentWishlist.mockReset();
+  });
+
+  it("lists wishlist items with a predictable order", async () => {
+    const items = [
+      {
+        id: "item-1",
+        wishlistId: "wishlist-1",
+        title: "Item 1",
+        url: null,
+        note: null,
+        price: null,
+        createdAt: new Date("2026-04-11T00:00:00.000Z"),
+        updatedAt: new Date("2026-04-11T00:00:00.000Z"),
+      },
+    ];
+
+    mocks.findWishlistItems.mockResolvedValue(items);
+
+    await expect(listWishlistItems("wishlist-1")).resolves.toEqual(items);
+    expect(mocks.findWishlistItems).toHaveBeenCalledOnce();
+  });
+
+  it("loads a wishlist together with its items", async () => {
+    const wishlist = {
+      id: "wishlist-1",
+      userId: "user-1",
+      isActive: true,
+      createdAt: new Date("2026-04-11T00:00:00.000Z"),
+      updatedAt: new Date("2026-04-11T00:00:00.000Z"),
+    };
+    const items = [
+      {
+        id: "item-1",
+        wishlistId: "wishlist-1",
+        title: "Item 1",
+        url: null,
+        note: null,
+        price: null,
+        createdAt: new Date("2026-04-11T00:00:00.000Z"),
+        updatedAt: new Date("2026-04-11T00:00:00.000Z"),
+      },
+    ];
+
+    mocks.findWishlists.mockResolvedValue(wishlist);
+    mocks.findWishlistItems.mockResolvedValue(items);
+
+    await expect(getWishlistWithItems("wishlist-1")).resolves.toEqual({
+      ...wishlist,
+      items,
+    });
+  });
+
+  it("returns null when the wishlist does not exist", async () => {
+    mocks.findWishlists.mockResolvedValue(undefined);
+
+    await expect(getWishlistWithItems("wishlist-1")).resolves.toBeNull();
+    expect(mocks.findWishlistItems).not.toHaveBeenCalled();
+  });
+
+  it("loads the current owner wishlist together with its items", async () => {
+    const wishlist = {
+      id: "wishlist-1",
+      userId: "user-1",
+      isActive: true,
+      createdAt: new Date("2026-04-11T00:00:00.000Z"),
+      updatedAt: new Date("2026-04-11T00:00:00.000Z"),
+    };
+    const items = [
+      {
+        id: "item-1",
+        wishlistId: "wishlist-1",
+        title: "Item 1",
+        url: null,
+        note: null,
+        price: null,
+        createdAt: new Date("2026-04-11T00:00:00.000Z"),
+        updatedAt: new Date("2026-04-11T00:00:00.000Z"),
+      },
+    ];
+
+    mocks.getOrCreateCurrentWishlist.mockResolvedValue(wishlist);
+    mocks.findWishlistItems.mockResolvedValue(items);
+
+    await expect(getCurrentWishlistWithItems("user-1")).resolves.toEqual({
+      ...wishlist,
+      items,
+    });
+    expect(mocks.getOrCreateCurrentWishlist).toHaveBeenCalledWith("user-1");
+  });
+});


### PR DESCRIPTION
Closes #35 

Load the current owner wishlist and its items on `/app` so the route becomes the first real wishlist dashboard instead of a placeholder. Keep the implementation server-first by reusing the existing auth guard, current wishlist bootstrap, and wishlist item read helpers without stepping into item mutations yet.

## What changed

* replaced the `/app` placeholder with real owner dashboard data loading
* reused the existing auth guard to resolve the authenticated owner
* loaded the current wishlist and its items through `getCurrentWishlistWithItems(user.id)`
* kept all wishlist reads inside the wishlist module instead of placing raw queries in the route
* added a real empty state for owners who have a wishlist but no items yet
* added item list rendering for existing wishlist items
* updated Russian UI strings for the owner dashboard state

## How to verify

* sign in with a valid owner account
* open `/app`
* confirm the route renders a real wishlist dashboard instead of a placeholder
* confirm the page loads through the existing auth guard and current wishlist helpers
* if the current wishlist has no items, confirm the empty state is shown
* if the current wishlist has items, confirm the list renders item title and optional fields such as URL, note, and price
* confirm the route does not introduce client-side dashboard state or mutation behavior

## Tests

* `npm run typecheck`
* `npx vitest run tests/unit/wishlist-items.test.ts tests/unit/wishlist-app-bootstrap.test.ts tests/unit/wishlist-current-wishlist.test.ts`
* `npm run build`

## Documentation

* updated Russian dashboard strings in `src/modules/i18n/dictionaries/ru/app.ts`
