### PR TITLE
test(wishlist): expand milestone 3 coverage

### DIFF
--- a/tests/unit/wishlist-app-bootstrap.test.ts
+++ b/tests/unit/wishlist-app-bootstrap.test.ts
@@ -70,6 +70,60 @@ describe("owner app wishlist bootstrap", () => {
     expect(html).toContain("Добавить желание");
   });
 
+  it("renders create success feedback when redirected after item creation", async () => {
+    const { default: AppPage } = await import("../../src/app/app/page");
+
+    const page = await AppPage({
+      searchParams: Promise.resolve({ status: "item-created" }),
+    });
+    const html = renderToStaticMarkup(page);
+
+    expect(html).toContain("Желание добавлено в текущий вишлист.");
+  });
+
+  it("renders update and delete success feedback with action-aware state", async () => {
+    const { default: AppPage } = await import("../../src/app/app/page");
+
+    const updatedPage = await AppPage({
+      searchParams: Promise.resolve({ status: "item-updated" }),
+    });
+    const deletedPage = await AppPage({
+      searchParams: Promise.resolve({ status: "item-deleted" }),
+    });
+
+    expect(renderToStaticMarkup(updatedPage)).toContain("Желание обновлено.");
+    expect(renderToStaticMarkup(deletedPage)).toContain("Желание удалено из текущего вишлиста.");
+  });
+
+  it("renders action-aware error feedback for create, update, and delete flows", async () => {
+    const { default: AppPage } = await import("../../src/app/app/page");
+
+    const createPage = await AppPage({
+      searchParams: Promise.resolve({ action: "create", error: "unknown" }),
+    });
+    const updatePage = await AppPage({
+      searchParams: Promise.resolve({ action: "update", error: "unknown" }),
+    });
+    const deletePage = await AppPage({
+      searchParams: Promise.resolve({ action: "delete", error: "unknown" }),
+    });
+
+    expect(renderToStaticMarkup(createPage)).toContain("Не удалось добавить желание. Попробуйте ещё раз.");
+    expect(renderToStaticMarkup(updatePage)).toContain("Не удалось сохранить изменения. Попробуйте ещё раз.");
+    expect(renderToStaticMarkup(deletePage)).toContain("Не удалось удалить желание. Попробуйте ещё раз.");
+  });
+
+  it("renders item-not-found feedback for owner-scoped update or delete failures", async () => {
+    const { default: AppPage } = await import("../../src/app/app/page");
+
+    const page = await AppPage({
+      searchParams: Promise.resolve({ action: "update", error: "item-not-found" }),
+    });
+    const html = renderToStaticMarkup(page);
+
+    expect(html).toContain("Не удалось найти это желание в текущем вишлисте.");
+  });
+
   it("renders wishlist items when they exist", async () => {
     mocks.getCurrentWishlistWithItems.mockResolvedValue({
       id: "wishlist-1",

--- a/tests/unit/wishlist-create-item.test.ts
+++ b/tests/unit/wishlist-create-item.test.ts
@@ -54,6 +54,17 @@ describe("wishlist item creation validation", () => {
       }),
     ).toEqual({ status: "error", code: "invalid-price" });
   });
+
+  it("rejects non-numeric prices", () => {
+    expect(
+      validateCreateWishlistItemInput({
+        title: "Наушники",
+        url: "",
+        note: "",
+        price: "abc",
+      }),
+    ).toEqual({ status: "error", code: "invalid-price" });
+  });
 });
 
 describe("wishlist item creation flow", () => {

--- a/tests/unit/wishlist-current-wishlist.test.ts
+++ b/tests/unit/wishlist-current-wishlist.test.ts
@@ -18,7 +18,10 @@ vi.mock("../../src/shared/db", () => ({
   },
 }));
 
-import { getOrCreateCurrentWishlist } from "../../src/modules/wishlist/server/current-wishlist";
+import {
+  getCurrentWishlist,
+  getOrCreateCurrentWishlist,
+} from "../../src/modules/wishlist/server/current-wishlist";
 
 describe("current owner wishlist bootstrap", () => {
   beforeEach(() => {
@@ -33,6 +36,28 @@ describe("current owner wishlist bootstrap", () => {
     mocks.insertValues.mockReturnValue({
       returning: mocks.insertReturning,
     });
+  });
+
+  it("returns the current wishlist without creating one in read-only mode", async () => {
+    const wishlist = {
+      id: "wishlist-1",
+      userId: "user-1",
+      isActive: true,
+      createdAt: new Date("2026-04-11T00:00:00.000Z"),
+      updatedAt: new Date("2026-04-11T00:00:00.000Z"),
+    };
+
+    mocks.findFirst.mockResolvedValueOnce(wishlist);
+
+    await expect(getCurrentWishlist("user-1")).resolves.toEqual(wishlist);
+    expect(mocks.insert).not.toHaveBeenCalled();
+  });
+
+  it("returns null in read-only mode when the owner has no wishlist", async () => {
+    mocks.findFirst.mockResolvedValueOnce(undefined).mockResolvedValueOnce(undefined);
+
+    await expect(getCurrentWishlist("user-1")).resolves.toBeNull();
+    expect(mocks.insert).not.toHaveBeenCalled();
   });
 
   it("returns the current active wishlist when it exists", async () => {


### PR DESCRIPTION
Closes #38 

Cover the implemented wishlist milestone with focused tests for owner bootstrap, dashboard rendering, item mutations, and owner-scoped behavior before moving on to sharing and reservations. Keep the suite fast and maintainable by extending unit and integration-like route tests instead of adding heavier end-to-end infrastructure for the same milestone scope.

## What changed

- expanded wishlist bootstrap coverage for:
  - predictable current wishlist selection
  - wishlist creation on first owner access
  - no duplicate wishlist creation on repeated access
  - read-only current wishlist lookup without bootstrap side effects
- expanded owner dashboard coverage for:
  - loading current wishlist and items on `/app`
  - empty state rendering
  - item list rendering
- expanded item creation coverage for:
  - successful create
  - empty title
  - invalid URL
  - negative price
  - non-numeric price
- strengthened item management coverage for:
  - successful update
  - invalid update input
  - update outside the current owner wishlist
  - successful delete
  - delete outside the current owner wishlist
  - update/delete behavior when no current wishlist exists
- added coverage for action-aware dashboard feedback on `/app`, including:
  - success messages for create/update/delete
  - action-aware unknown errors
  - `item-not-found` feedback

## How to verify

- inspect the updated wishlist unit tests and confirm the milestone 3 scenarios are covered
- confirm the suite covers both bootstrap/read behavior and owner-scoped item mutations
- confirm the dashboard test coverage includes both empty state and populated item rendering
- confirm update/delete tests cover the no-bootstrap-on-mutation behavior
- run the wishlist-focused test commands and confirm they pass cleanly

## Tests

- `npx vitest run tests/unit/wishlist-current-wishlist.test.ts tests/unit/wishlist-items.test.ts tests/unit/wishlist-create-item.test.ts tests/unit/wishlist-manage-item.test.ts tests/unit/wishlist-app-bootstrap.test.ts`
- `npm run build`
- `npm run typecheck`

## Documentation

- no additional product or process documentation changes required for this PR