### PR TITLE
feat(share): add owner share link helpers

### DIFF
--- a/src/modules/share/index.ts
+++ b/src/modules/share/index.ts
@@ -1,1 +1,7 @@
-export {};
+export { shareLinks } from "@/modules/share/db/schema";
+export {
+  type CurrentShareLink,
+  generateShareToken,
+  getCurrentShareLink,
+  getOrCreateCurrentShareLink,
+} from "@/modules/share/server";

--- a/src/modules/share/server/current-share-link.ts
+++ b/src/modules/share/server/current-share-link.ts
@@ -1,0 +1,115 @@
+import { and, asc, eq } from "drizzle-orm";
+import { DatabaseError } from "pg";
+import { shareLinks } from "@/modules/share/db/schema";
+import { generateShareToken } from "@/modules/share/server/token";
+import {
+  getCurrentWishlist,
+  getOrCreateCurrentWishlist,
+} from "@/modules/wishlist/server/current-wishlist";
+
+const MAX_CREATE_SHARE_LINK_ATTEMPTS = 5;
+
+export type CurrentShareLink = {
+  id: string;
+  wishlistId: string;
+  token: string;
+  isActive: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+export async function getCurrentShareLink(userId: string): Promise<CurrentShareLink | null> {
+  const wishlist = await getCurrentWishlist(userId);
+
+  if (!wishlist) {
+    return null;
+  }
+
+  return findActiveShareLinkByWishlistId(wishlist.id);
+}
+
+export async function getOrCreateCurrentShareLink(userId: string): Promise<CurrentShareLink> {
+  const wishlist = await getOrCreateCurrentWishlist(userId);
+  const currentShareLink = await findActiveShareLinkByWishlistId(wishlist.id);
+
+  if (currentShareLink) {
+    return currentShareLink;
+  }
+
+  return createActiveShareLink(wishlist.id);
+}
+
+async function createActiveShareLink(wishlistId: string): Promise<CurrentShareLink> {
+  const db = await getDb();
+
+  for (let attempt = 0; attempt < MAX_CREATE_SHARE_LINK_ATTEMPTS; attempt += 1) {
+    try {
+      const [createdShareLink] = await db
+        .insert(shareLinks)
+        .values({
+          wishlistId,
+          token: generateShareToken(),
+          isActive: true,
+        })
+        .returning({
+          id: shareLinks.id,
+          wishlistId: shareLinks.wishlistId,
+          token: shareLinks.token,
+          isActive: shareLinks.isActive,
+          createdAt: shareLinks.createdAt,
+          updatedAt: shareLinks.updatedAt,
+        });
+
+      if (!createdShareLink) {
+        throw new Error("Failed to create active share link.");
+      }
+
+      return createdShareLink;
+    } catch (error) {
+      if (!isUniqueViolation(error)) {
+        throw error;
+      }
+
+      const existingShareLink = await findActiveShareLinkByWishlistId(wishlistId);
+
+      if (existingShareLink) {
+        return existingShareLink;
+      }
+    }
+  }
+
+  throw new Error("Failed to create active share link.");
+}
+
+async function findActiveShareLinkByWishlistId(wishlistId: string): Promise<CurrentShareLink | null> {
+  const db = await getDb();
+
+  const activeShareLink = await db.query.shareLinks.findFirst({
+    columns: {
+      id: true,
+      wishlistId: true,
+      token: true,
+      isActive: true,
+      createdAt: true,
+      updatedAt: true,
+    },
+    where: and(eq(shareLinks.wishlistId, wishlistId), eq(shareLinks.isActive, true)),
+    orderBy: [asc(shareLinks.createdAt), asc(shareLinks.id)],
+  });
+
+  if (!activeShareLink || !activeShareLink.isActive) {
+    return null;
+  }
+
+  return activeShareLink;
+}
+
+function isUniqueViolation(error: unknown): boolean {
+  return error instanceof DatabaseError && error.code === "23505";
+}
+
+async function getDb() {
+  const { db } = await import("@/shared/db");
+
+  return db;
+}

--- a/src/modules/share/server/index.ts
+++ b/src/modules/share/server/index.ts
@@ -1,0 +1,6 @@
+export {
+  type CurrentShareLink,
+  getCurrentShareLink,
+  getOrCreateCurrentShareLink,
+} from "@/modules/share/server/current-share-link";
+export { generateShareToken } from "@/modules/share/server/token";

--- a/src/modules/share/server/token.ts
+++ b/src/modules/share/server/token.ts
@@ -1,0 +1,5 @@
+import { randomBytes } from "node:crypto";
+
+export function generateShareToken(): string {
+  return randomBytes(32).toString("base64url");
+}

--- a/src/shared/db/client.ts
+++ b/src/shared/db/client.ts
@@ -1,6 +1,7 @@
 import { drizzle } from "drizzle-orm/node-postgres";
 import { Pool } from "pg";
 import * as authSchema from "@/modules/auth/db/schema";
+import * as shareSchema from "@/modules/share/db/schema";
 import * as wishlistSchema from "@/modules/wishlist/db/schema";
 import { getDatabaseEnv } from "@/shared/db/env";
 
@@ -14,6 +15,7 @@ export const pool = new Pool({
 export const db = drizzle(pool, {
   schema: {
     ...authSchema,
+    ...shareSchema,
     ...wishlistSchema,
   },
 });

--- a/tests/unit/share-current-share-link.test.ts
+++ b/tests/unit/share-current-share-link.test.ts
@@ -1,0 +1,171 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { DatabaseError } from "pg";
+
+const mocks = vi.hoisted(() => ({
+  findShareLink: vi.fn(),
+  insert: vi.fn(),
+  insertValues: vi.fn(),
+  insertReturning: vi.fn(),
+  getCurrentWishlist: vi.fn(),
+  getOrCreateCurrentWishlist: vi.fn(),
+  generateShareToken: vi.fn(),
+}));
+
+vi.mock("../../src/shared/db", () => ({
+  db: {
+    query: {
+      shareLinks: {
+        findFirst: mocks.findShareLink,
+      },
+    },
+    insert: mocks.insert,
+  },
+}));
+
+vi.mock("../../src/modules/wishlist/server/current-wishlist", () => ({
+  getCurrentWishlist: mocks.getCurrentWishlist,
+  getOrCreateCurrentWishlist: mocks.getOrCreateCurrentWishlist,
+}));
+
+vi.mock("../../src/modules/share/server/token", () => ({
+  generateShareToken: mocks.generateShareToken,
+}));
+
+import {
+  getCurrentShareLink,
+  getOrCreateCurrentShareLink,
+} from "../../src/modules/share/server/current-share-link";
+
+describe("current owner share link helpers", () => {
+  beforeEach(() => {
+    mocks.findShareLink.mockReset();
+    mocks.insert.mockReset();
+    mocks.insertValues.mockReset();
+    mocks.insertReturning.mockReset();
+    mocks.getCurrentWishlist.mockReset();
+    mocks.getOrCreateCurrentWishlist.mockReset();
+    mocks.generateShareToken.mockReset();
+
+    mocks.insert.mockReturnValue({
+      values: mocks.insertValues,
+    });
+    mocks.insertValues.mockReturnValue({
+      returning: mocks.insertReturning,
+    });
+  });
+
+  it("returns null in read-only mode when the owner has no current wishlist", async () => {
+    mocks.getCurrentWishlist.mockResolvedValue(null);
+
+    await expect(getCurrentShareLink("user-1")).resolves.toBeNull();
+    expect(mocks.findShareLink).not.toHaveBeenCalled();
+    expect(mocks.insert).not.toHaveBeenCalled();
+  });
+
+  it("returns the current active share link without creating one in read-only mode", async () => {
+    const wishlist = {
+      id: "wishlist-1",
+      userId: "user-1",
+      isActive: true,
+      createdAt: new Date("2026-04-12T00:00:00.000Z"),
+      updatedAt: new Date("2026-04-12T00:00:00.000Z"),
+    };
+    const shareLink = {
+      id: "share-1",
+      wishlistId: "wishlist-1",
+      token: "opaque-token",
+      isActive: true,
+      createdAt: new Date("2026-04-12T00:00:00.000Z"),
+      updatedAt: new Date("2026-04-12T00:00:00.000Z"),
+    };
+
+    mocks.getCurrentWishlist.mockResolvedValue(wishlist);
+    mocks.findShareLink.mockResolvedValue(shareLink);
+
+    await expect(getCurrentShareLink("user-1")).resolves.toEqual(shareLink);
+    expect(mocks.insert).not.toHaveBeenCalled();
+  });
+
+  it("returns the existing active share link for the current owner wishlist", async () => {
+    const wishlist = {
+      id: "wishlist-1",
+      userId: "user-1",
+      isActive: true,
+      createdAt: new Date("2026-04-12T00:00:00.000Z"),
+      updatedAt: new Date("2026-04-12T00:00:00.000Z"),
+    };
+    const shareLink = {
+      id: "share-1",
+      wishlistId: "wishlist-1",
+      token: "opaque-token",
+      isActive: true,
+      createdAt: new Date("2026-04-12T00:00:00.000Z"),
+      updatedAt: new Date("2026-04-12T00:00:00.000Z"),
+    };
+
+    mocks.getOrCreateCurrentWishlist.mockResolvedValue(wishlist);
+    mocks.findShareLink.mockResolvedValue(shareLink);
+
+    await expect(getOrCreateCurrentShareLink("user-1")).resolves.toEqual(shareLink);
+    expect(mocks.insert).not.toHaveBeenCalled();
+  });
+
+  it("creates an active share link when the current owner wishlist has none", async () => {
+    const wishlist = {
+      id: "wishlist-1",
+      userId: "user-1",
+      isActive: true,
+      createdAt: new Date("2026-04-12T00:00:00.000Z"),
+      updatedAt: new Date("2026-04-12T00:00:00.000Z"),
+    };
+    const shareLink = {
+      id: "share-1",
+      wishlistId: "wishlist-1",
+      token: "generated-token",
+      isActive: true,
+      createdAt: new Date("2026-04-12T00:00:00.000Z"),
+      updatedAt: new Date("2026-04-12T00:00:00.000Z"),
+    };
+
+    mocks.getOrCreateCurrentWishlist.mockResolvedValue(wishlist);
+    mocks.findShareLink.mockResolvedValueOnce(undefined);
+    mocks.generateShareToken.mockReturnValue("generated-token");
+    mocks.insertReturning.mockResolvedValue([shareLink]);
+
+    await expect(getOrCreateCurrentShareLink("user-1")).resolves.toEqual(shareLink);
+    expect(mocks.insertValues).toHaveBeenCalledWith({
+      wishlistId: "wishlist-1",
+      token: "generated-token",
+      isActive: true,
+    });
+  });
+
+  it("returns the existing active share link when create races with another request", async () => {
+    const duplicateKeyError = new DatabaseError("duplicate key", 0, "error");
+    duplicateKeyError.code = "23505";
+
+    const wishlist = {
+      id: "wishlist-1",
+      userId: "user-1",
+      isActive: true,
+      createdAt: new Date("2026-04-12T00:00:00.000Z"),
+      updatedAt: new Date("2026-04-12T00:00:00.000Z"),
+    };
+    const shareLink = {
+      id: "share-1",
+      wishlistId: "wishlist-1",
+      token: "existing-token",
+      isActive: true,
+      createdAt: new Date("2026-04-12T00:00:00.000Z"),
+      updatedAt: new Date("2026-04-12T00:00:00.000Z"),
+    };
+
+    mocks.getOrCreateCurrentWishlist.mockResolvedValue(wishlist);
+    mocks.findShareLink.mockResolvedValueOnce(undefined).mockResolvedValueOnce(shareLink);
+    mocks.generateShareToken.mockReturnValue("generated-token");
+    mocks.insertReturning.mockRejectedValue(duplicateKeyError);
+
+    await expect(getOrCreateCurrentShareLink("user-1")).resolves.toEqual(shareLink);
+    expect(mocks.insert).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/unit/share-token.test.ts
+++ b/tests/unit/share-token.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { generateShareToken } from "../../src/modules/share/server/token";
+
+describe("share token generation", () => {
+  it("creates opaque url-safe tokens", () => {
+    const firstToken = generateShareToken();
+    const secondToken = generateShareToken();
+
+    expect(firstToken).toMatch(/^[A-Za-z0-9_-]+$/);
+    expect(firstToken.length).toBeGreaterThanOrEqual(43);
+    expect(secondToken).toMatch(/^[A-Za-z0-9_-]+$/);
+    expect(secondToken.length).toBeGreaterThanOrEqual(43);
+    expect(firstToken).not.toEqual(secondToken);
+  });
+});


### PR DESCRIPTION
Closes #48 

Add the server-side share-link helper foundation for the current owner wishlist so the next milestone PRs can build dashboard controls, public token loading, and revoke/regenerate behavior on top of one small, reusable module-owned API.

## What changed

* added opaque share token generation in `src/modules/share/server/token.ts`
* added owner-side current share link helpers in `src/modules/share/server/current-share-link.ts`
* added `generateShareToken()` for secure URL-safe token generation
* added `getCurrentShareLink(userId)` for read-only lookup of the current active share link
* added `getOrCreateCurrentShareLink(userId)` for owner-side get-or-create behavior without duplicate active links in normal flow
* added minimal server-side share module exports for the new helper foundation
* updated DB wiring needed for the new share helper reads and writes

## How to verify

* inspect `src/modules/share/server/token.ts` and confirm token generation is opaque and not derived from predictable identifiers
* inspect `src/modules/share/server/current-share-link.ts`
* confirm `getCurrentShareLink(userId)` returns the active share link in read-only mode
* confirm `getCurrentShareLink(userId)` returns `null` when the owner has no current wishlist or no active share link
* confirm `getOrCreateCurrentShareLink(userId)` returns the existing active share link without creating duplicates
* confirm `getOrCreateCurrentShareLink(userId)` creates one active share link when none exists
* confirm no owner UI controls, public route loading, or revoke/regenerate behavior were added in this PR

## Tests

* `npx vitest run tests/unit/share-token.test.ts tests/unit/share-current-share-link.test.ts`
* `npm run typecheck`

## Documentation

* no additional product or process documentation changes required for this PR
