### PR TITLE
feat(share): add public wishlist loading helpers

### DIFF
--- a/src/modules/share/index.ts
+++ b/src/modules/share/index.ts
@@ -1,7 +1,10 @@
 export { shareLinks } from "@/modules/share/db/schema";
 export {
   type CurrentShareLink,
+  type PublicWishlist,
   generateShareToken,
+  getActiveShareLinkByToken,
   getCurrentShareLink,
   getOrCreateCurrentShareLink,
+  getPublicWishlistByShareToken,
 } from "@/modules/share/server";

--- a/src/modules/share/server/index.ts
+++ b/src/modules/share/server/index.ts
@@ -3,4 +3,9 @@ export {
   getCurrentShareLink,
   getOrCreateCurrentShareLink,
 } from "@/modules/share/server/current-share-link";
+export {
+  type PublicWishlist,
+  getActiveShareLinkByToken,
+  getPublicWishlistByShareToken,
+} from "@/modules/share/server/public-wishlist";
 export { generateShareToken } from "@/modules/share/server/token";

--- a/src/modules/share/server/public-wishlist.ts
+++ b/src/modules/share/server/public-wishlist.ts
@@ -1,0 +1,69 @@
+import { and, eq } from "drizzle-orm";
+import { shareLinks } from "@/modules/share/db/schema";
+import { type CurrentShareLink } from "@/modules/share/server/current-share-link";
+import {
+  getWishlistWithItems,
+  type WishlistItemRecord,
+} from "@/modules/wishlist/server/items";
+
+export type PublicWishlist = {
+  id: string;
+  items: WishlistItemRecord[];
+  shareLink: {
+    id: string;
+    token: string;
+  };
+};
+
+export async function getActiveShareLinkByToken(token: string): Promise<CurrentShareLink | null> {
+  const normalizedToken = token.trim();
+
+  if (!normalizedToken) {
+    return null;
+  }
+
+  const db = await getDb();
+
+  return (
+    (await db.query.shareLinks.findFirst({
+      columns: {
+        id: true,
+        wishlistId: true,
+        token: true,
+        isActive: true,
+        createdAt: true,
+        updatedAt: true,
+      },
+      where: and(eq(shareLinks.token, normalizedToken), eq(shareLinks.isActive, true)),
+    })) ?? null
+  );
+}
+
+export async function getPublicWishlistByShareToken(token: string): Promise<PublicWishlist | null> {
+  const shareLink = await getActiveShareLinkByToken(token);
+
+  if (!shareLink) {
+    return null;
+  }
+
+  const wishlist = await getWishlistWithItems(shareLink.wishlistId);
+
+  if (!wishlist) {
+    return null;
+  }
+
+  return {
+    id: wishlist.id,
+    items: wishlist.items,
+    shareLink: {
+      id: shareLink.id,
+      token: shareLink.token,
+    },
+  };
+}
+
+async function getDb() {
+  const { db } = await import("@/shared/db");
+
+  return db;
+}

--- a/tests/unit/share-public-wishlist.test.ts
+++ b/tests/unit/share-public-wishlist.test.ts
@@ -1,0 +1,123 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  findShareLink: vi.fn(),
+  getWishlistWithItems: vi.fn(),
+}));
+
+vi.mock("../../src/shared/db", () => ({
+  db: {
+    query: {
+      shareLinks: {
+        findFirst: mocks.findShareLink,
+      },
+    },
+  },
+}));
+
+vi.mock("../../src/modules/wishlist/server/items", () => ({
+  getWishlistWithItems: mocks.getWishlistWithItems,
+}));
+
+import {
+  getActiveShareLinkByToken,
+  getPublicWishlistByShareToken,
+} from "../../src/modules/share/server/public-wishlist";
+
+describe("public wishlist loading by share token", () => {
+  beforeEach(() => {
+    mocks.findShareLink.mockReset();
+    mocks.getWishlistWithItems.mockReset();
+  });
+
+  it("returns null for a missing token", async () => {
+    await expect(getActiveShareLinkByToken("")).resolves.toBeNull();
+    expect(mocks.findShareLink).not.toHaveBeenCalled();
+  });
+
+  it("loads the active share link by opaque token", async () => {
+    const shareLink = {
+      id: "share-1",
+      wishlistId: "wishlist-1",
+      token: "opaque-token",
+      isActive: true,
+      createdAt: new Date("2026-04-12T00:00:00.000Z"),
+      updatedAt: new Date("2026-04-12T00:00:00.000Z"),
+    };
+
+    mocks.findShareLink.mockResolvedValue(shareLink);
+
+    await expect(getActiveShareLinkByToken(" opaque-token ")).resolves.toEqual(shareLink);
+  });
+
+  it("returns null when the token does not exist", async () => {
+    mocks.findShareLink.mockResolvedValue(undefined);
+
+    await expect(getPublicWishlistByShareToken("missing-token")).resolves.toBeNull();
+    expect(mocks.getWishlistWithItems).not.toHaveBeenCalled();
+  });
+
+  it("returns null when the active token points to a missing wishlist", async () => {
+    mocks.findShareLink.mockResolvedValue({
+      id: "share-1",
+      wishlistId: "wishlist-1",
+      token: "opaque-token",
+      isActive: true,
+      createdAt: new Date("2026-04-12T00:00:00.000Z"),
+      updatedAt: new Date("2026-04-12T00:00:00.000Z"),
+    });
+    mocks.getWishlistWithItems.mockResolvedValue(null);
+
+    await expect(getPublicWishlistByShareToken("opaque-token")).resolves.toBeNull();
+  });
+
+  it("loads the public wishlist and items for a valid active token", async () => {
+    mocks.findShareLink.mockResolvedValue({
+      id: "share-1",
+      wishlistId: "wishlist-1",
+      token: "opaque-token",
+      isActive: true,
+      createdAt: new Date("2026-04-12T00:00:00.000Z"),
+      updatedAt: new Date("2026-04-12T00:00:00.000Z"),
+    });
+    mocks.getWishlistWithItems.mockResolvedValue({
+      id: "wishlist-1",
+      userId: "owner-1",
+      isActive: true,
+      createdAt: new Date("2026-04-11T00:00:00.000Z"),
+      updatedAt: new Date("2026-04-11T00:00:00.000Z"),
+      items: [
+        {
+          id: "item-1",
+          wishlistId: "wishlist-1",
+          title: "Наушники",
+          url: "https://example.com/item",
+          note: "Нужны беспроводные",
+          price: "9990.00",
+          createdAt: new Date("2026-04-11T00:00:00.000Z"),
+          updatedAt: new Date("2026-04-11T00:00:00.000Z"),
+        },
+      ],
+    });
+
+    await expect(getPublicWishlistByShareToken("opaque-token")).resolves.toEqual({
+      id: "wishlist-1",
+      items: [
+        {
+          id: "item-1",
+          wishlistId: "wishlist-1",
+          title: "Наушники",
+          url: "https://example.com/item",
+          note: "Нужны беспроводные",
+          price: "9990.00",
+          createdAt: new Date("2026-04-11T00:00:00.000Z"),
+          updatedAt: new Date("2026-04-11T00:00:00.000Z"),
+        },
+      ],
+      shareLink: {
+        id: "share-1",
+        token: "opaque-token",
+      },
+    });
+  });
+});


### PR DESCRIPTION
Closes #50 

Add the server-side public wishlist loading foundation so the upcoming `/share/[token]` route can resolve an active share token into a read-only wishlist without duplicating token lookup or wishlist/item read logic in the route layer.

## What changed

* added a public loading layer in `src/modules/share/server/public-wishlist.ts`
* added `getActiveShareLinkByToken(token)` for active opaque token lookup
* added `getPublicWishlistByShareToken(token)` for loading a public read-only wishlist with items
* added a minimal public result shape that excludes owner-specific fields
* exported the new public loading helpers through the share module entry points
* added focused unit coverage for valid, invalid, inactive, and missing-token cases

## How to verify

* inspect `src/modules/share/server/public-wishlist.ts`
* confirm the public loading logic lives inside the share module rather than in a route
* confirm a missing token returns `null`
* confirm an invalid token returns `null`
* confirm an inactive token returns `null`
* confirm a valid active token returns wishlist and item data in a read-only public shape
* confirm the public result does not expose owner-only data

## Tests

* `npx vitest run tests/unit/share-token.test.ts tests/unit/share-current-share-link.test.ts tests/unit/share-public-wishlist.test.ts`
* `npm run typecheck`
* `npm run build`

## Documentation

* no additional product or process documentation changes required for this PR
