### PR TITLE
feat(share): render public wishlist route

### DIFF
--- a/src/app/share/[token]/page.tsx
+++ b/src/app/share/[token]/page.tsx
@@ -1,15 +1,90 @@
+import Link from "next/link";
+import { getPublicWishlistByShareToken } from "@/modules/share";
 import { getTranslations } from "@/modules/i18n";
 import { PageShell } from "@/shared/ui/page-shell";
 
 const common = getTranslations("common");
 const messages = getTranslations("app");
 
-export default function SharePage() {
+type SharePageProps = {
+  params?: Promise<{
+    token?: string;
+  }>;
+};
+
+export default async function SharePage(props: SharePageProps) {
+  const params = props?.params ? await props.params : undefined;
+  const publicWishlist = await getPublicWishlistByShareToken(params?.token ?? "");
+
+  if (!publicWishlist) {
+    return (
+      <PageShell
+        eyebrow={common.brand}
+        title={messages.share.unavailableTitle}
+        description={messages.share.unavailableDescription}
+      />
+    );
+  }
+
   return (
     <PageShell
-      eyebrow={common.routeSkeleton}
+      eyebrow={common.brand}
       title={messages.share.title}
       description={messages.share.description}
-    />
+    >
+      {publicWishlist.items.length === 0 ? (
+        <section className="ui-surface p-6">
+          <h2 className="text-lg font-semibold text-[color:var(--color-text-strong)]">
+            {messages.share.emptyTitle}
+          </h2>
+          <p className="mt-3 text-[color:var(--color-text-base)]">
+            {messages.share.emptyDescription}
+          </p>
+        </section>
+      ) : (
+        <section className="space-y-4">
+          <h2 className="text-lg font-semibold text-[color:var(--color-text-strong)]">
+            {messages.share.itemsTitle}
+          </h2>
+          <ul className="space-y-4">
+            {publicWishlist.items.map((item) => (
+              <li key={item.id} className="ui-surface p-6">
+                <div className="space-y-3">
+                  <h3 className="text-base font-semibold text-[color:var(--color-text-strong)]">
+                    {item.title}
+                  </h3>
+                  {item.url ? (
+                    <p className="text-sm text-[color:var(--color-text-base)] break-all">
+                      <span className="font-medium text-[color:var(--color-text-strong)]">
+                        {messages.share.itemFields.url}: 
+                      </span>
+                      <Link href={item.url} className="underline underline-offset-2">
+                        {item.url}
+                      </Link>
+                    </p>
+                  ) : null}
+                  {item.note ? (
+                    <p className="text-sm text-[color:var(--color-text-base)]">
+                      <span className="font-medium text-[color:var(--color-text-strong)]">
+                        {messages.share.itemFields.note}: 
+                      </span>
+                      {item.note}
+                    </p>
+                  ) : null}
+                  {item.price ? (
+                    <p className="text-sm text-[color:var(--color-text-base)]">
+                      <span className="font-medium text-[color:var(--color-text-strong)]">
+                        {messages.share.itemFields.price}: 
+                      </span>
+                      {item.price}
+                    </p>
+                  ) : null}
+                </div>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+    </PageShell>
   );
 }

--- a/src/modules/i18n/dictionaries/ru/app.ts
+++ b/src/modules/i18n/dictionaries/ru/app.ts
@@ -99,6 +99,16 @@ export const app = {
   },
   share: {
     title: "Публичный вишлист",
-    description: "Публичный рендеринг списка появится после начала milestone sharing.",
+    description: "Здесь можно посмотреть желания из вишлиста по публичной ссылке в режиме только чтения.",
+    unavailableTitle: "Публичная ссылка недоступна",
+    unavailableDescription: "Эта ссылка недействительна или больше неактивна.",
+    emptyTitle: "Этот вишлист пока пуст",
+    emptyDescription: "Владелец ещё не добавил сюда желания.",
+    itemsTitle: "Желания",
+    itemFields: {
+      url: "Ссылка",
+      note: "Заметка",
+      price: "Цена",
+    },
   },
 } as const;

--- a/tests/unit/share-page.test.ts
+++ b/tests/unit/share-page.test.ts
@@ -1,0 +1,90 @@
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getPublicWishlistByShareToken: vi.fn(),
+}));
+
+vi.mock("../../src/modules/share", () => ({
+  getPublicWishlistByShareToken: mocks.getPublicWishlistByShareToken,
+}));
+
+describe("public share route rendering", () => {
+  beforeEach(() => {
+    Object.assign(globalThis, { React });
+    mocks.getPublicWishlistByShareToken.mockReset();
+  });
+
+  it("renders an unavailable state for invalid or inactive tokens", async () => {
+    mocks.getPublicWishlistByShareToken.mockResolvedValue(null);
+
+    const { default: SharePage } = await import("../../src/app/share/[token]/page");
+    const page = await SharePage({
+      params: Promise.resolve({ token: "missing-token" }),
+    });
+    const html = renderToStaticMarkup(page);
+
+    expect(mocks.getPublicWishlistByShareToken).toHaveBeenCalledWith("missing-token");
+    expect(html).toContain("Публичная ссылка недоступна");
+    expect(html).toContain("Эта ссылка недействительна или больше неактивна.");
+  });
+
+  it("renders an empty public wishlist state when there are no items", async () => {
+    mocks.getPublicWishlistByShareToken.mockResolvedValue({
+      id: "wishlist-1",
+      items: [],
+      shareLink: {
+        id: "share-1",
+        token: "opaque-token",
+      },
+    });
+
+    const { default: SharePage } = await import("../../src/app/share/[token]/page");
+    const page = await SharePage({
+      params: Promise.resolve({ token: "opaque-token" }),
+    });
+    const html = renderToStaticMarkup(page);
+
+    expect(html).toContain("Публичный вишлист");
+    expect(html).toContain("Этот вишлист пока пуст");
+    expect(html).toContain("Владелец ещё не добавил сюда желания.");
+  });
+
+  it("renders public wishlist items in read-only mode for a valid token", async () => {
+    mocks.getPublicWishlistByShareToken.mockResolvedValue({
+      id: "wishlist-1",
+      items: [
+        {
+          id: "item-1",
+          wishlistId: "wishlist-1",
+          title: "Наушники",
+          url: "https://example.com/item",
+          note: "Нужны беспроводные",
+          price: "9990.00",
+          createdAt: new Date("2026-04-11T00:00:00.000Z"),
+          updatedAt: new Date("2026-04-11T00:00:00.000Z"),
+        },
+      ],
+      shareLink: {
+        id: "share-1",
+        token: "opaque-token",
+      },
+    });
+
+    const { default: SharePage } = await import("../../src/app/share/[token]/page");
+    const page = await SharePage({
+      params: Promise.resolve({ token: "opaque-token" }),
+    });
+    const html = renderToStaticMarkup(page);
+
+    expect(html).toContain("Публичный вишлист");
+    expect(html).toContain("Желания");
+    expect(html).toContain("Наушники");
+    expect(html).toContain("https://example.com/item");
+    expect(html).toContain("Нужны беспроводные");
+    expect(html).toContain("9990.00");
+    expect(html).not.toContain("Создать публичную ссылку");
+    expect(html).not.toContain("Сохранить изменения");
+  });
+});


### PR DESCRIPTION
Closes #51 

Render the public `/share/[token]` page so a valid active share token shows a read-only wishlist without exposing owner controls or reservation behavior. Keep the route server-first by reusing the existing share-module loading foundation instead of placing token lookup and wishlist reads directly in the route.

## What changed

* turned `/share/[token]` into a real server-rendered public page
* reused `getPublicWishlistByShareToken(token)` from the share module
* added a predictable unavailable state for invalid, inactive, or missing tokens
* added a dedicated empty state for valid public wishlists without items
* added read-only rendering for public wishlist items
* updated Russian public-share page strings
* added focused route-level tests for public share rendering states

## How to verify

* open `/share/<valid-active-token>` and confirm the page renders a read-only wishlist
* open `/share/<valid-active-token>` for a wishlist with no items and confirm the empty state is shown
* open `/share/<invalid-or-inactive-token>` and confirm the unavailable state is shown
* confirm the page does not show owner controls
* confirm the page does not show reservation actions
* confirm the route does not contain raw share DB logic

## Tests

* `npx vitest run tests/unit/share-page.test.ts tests/unit/share-public-wishlist.test.ts tests/unit/share-token.test.ts tests/unit/share-current-share-link.test.ts`
* `npm run typecheck`
* `npm run build`

## Documentation

* updated Russian share-page strings in `src/modules/i18n/dictionaries/ru/app.ts`
