### PR TITLE
feat: add reservation schema foundation

### DIFF
--- a/drizzle/0003_reservation-schema-foundation.sql
+++ b/drizzle/0003_reservation-schema-foundation.sql
@@ -1,0 +1,23 @@
+CREATE TABLE IF NOT EXISTS "reservations" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"wishlist_item_id" uuid NOT NULL,
+	"user_id" uuid NOT NULL,
+	"cancelled_at" timestamp with time zone,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "reservations" ADD CONSTRAINT "reservations_wishlist_item_id_wishlist_items_id_fk" FOREIGN KEY ("wishlist_item_id") REFERENCES "public"."wishlist_items"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "reservations" ADD CONSTRAINT "reservations_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "reservations_wishlist_item_id_idx" ON "reservations" USING btree ("wishlist_item_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "reservations_user_id_idx" ON "reservations" USING btree ("user_id");--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "reservations_wishlist_item_id_active_unique" ON "reservations" USING btree ("wishlist_item_id") WHERE "reservations"."cancelled_at" IS NULL;

--- a/drizzle/meta/0003_snapshot.json
+++ b/drizzle/meta/0003_snapshot.json
@@ -1,0 +1,632 @@
+{
+  "id": "6dcf8f9a-8e69-485e-a55c-4aa47d29ebac",
+  "prevId": "293f5eaa-9947-450d-9635-6451b0d127ae",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_token": {
+          "name": "session_token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_session_token_unique": {
+          "name": "sessions_session_token_unique",
+          "columns": [
+            {
+              "expression": "session_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_user_id_idx": {
+          "name": "sessions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_expires_at_idx": {
+          "name": "sessions_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reservations": {
+      "name": "reservations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "wishlist_item_id": {
+          "name": "wishlist_item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "reservations_wishlist_item_id_idx": {
+          "name": "reservations_wishlist_item_id_idx",
+          "columns": [
+            {
+              "expression": "wishlist_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reservations_user_id_idx": {
+          "name": "reservations_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reservations_wishlist_item_id_active_unique": {
+          "name": "reservations_wishlist_item_id_active_unique",
+          "columns": [
+            {
+              "expression": "wishlist_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"reservations\".\"cancelled_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reservations_wishlist_item_id_wishlist_items_id_fk": {
+          "name": "reservations_wishlist_item_id_wishlist_items_id_fk",
+          "tableFrom": "reservations",
+          "tableTo": "wishlist_items",
+          "columnsFrom": [
+            "wishlist_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reservations_user_id_users_id_fk": {
+          "name": "reservations_user_id_users_id_fk",
+          "tableFrom": "reservations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.share_links": {
+      "name": "share_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "wishlist_id": {
+          "name": "wishlist_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "share_links_token_unique": {
+          "name": "share_links_token_unique",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "share_links_wishlist_id_idx": {
+          "name": "share_links_wishlist_id_idx",
+          "columns": [
+            {
+              "expression": "wishlist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "share_links_wishlist_id_active_unique": {
+          "name": "share_links_wishlist_id_active_unique",
+          "columns": [
+            {
+              "expression": "wishlist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"share_links\".\"is_active\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "share_links_wishlist_id_wishlists_id_fk": {
+          "name": "share_links_wishlist_id_wishlists_id_fk",
+          "tableFrom": "share_links",
+          "tableTo": "wishlists",
+          "columnsFrom": [
+            "wishlist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wishlist_items": {
+      "name": "wishlist_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "wishlist_id": {
+          "name": "wishlist_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "wishlist_items_wishlist_id_idx": {
+          "name": "wishlist_items_wishlist_id_idx",
+          "columns": [
+            {
+              "expression": "wishlist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wishlist_items_wishlist_id_created_at_idx": {
+          "name": "wishlist_items_wishlist_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "wishlist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wishlist_items_wishlist_id_wishlists_id_fk": {
+          "name": "wishlist_items_wishlist_id_wishlists_id_fk",
+          "tableFrom": "wishlist_items",
+          "tableTo": "wishlists",
+          "columnsFrom": [
+            "wishlist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wishlists": {
+      "name": "wishlists",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "wishlists_user_id_idx": {
+          "name": "wishlists_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wishlists_user_id_is_active_idx": {
+          "name": "wishlists_user_id_is_active_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wishlists_user_id_users_id_fk": {
+          "name": "wishlists_user_id_users_id_fk",
+          "tableFrom": "wishlists",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1775940620615,
       "tag": "0002_jittery_wallop",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1775986656116,
+      "tag": "0003_reservation-schema-foundation",
+      "breakpoints": true
     }
   ]
 }

--- a/src/README.md
+++ b/src/README.md
@@ -16,7 +16,8 @@
 - `wishlist` is now an active feature module.
 - `share` is now an active feature module with schema, owner lifecycle helpers,
   public loading, and route rendering.
-- `reservation` remains the next product module to flesh out.
+- `reservation` now has its DB schema foundation in place for later milestone
+  issues.
 
 ## Module Areas
 - `auth`

--- a/src/modules/reservation/README.md
+++ b/src/modules/reservation/README.md
@@ -1,9 +1,19 @@
 # Reservation Module
 
 ## Current State
-- `index.ts` is still a placeholder module entry.
-- `/app/reservations` exists as a protected route placeholder for the next
-  milestone.
+- `src/modules/reservation/db/schema.ts` now owns the reservation DB
+  foundation.
+- `reservations` stores reservation history per wishlist item without adding
+  reserved flags to `wishlist_items`.
+- `/app/reservations` still exists as a protected route placeholder for a later
+  issue in this milestone.
+
+## Schema Foundation
+- Each reservation belongs to one `wishlist_item` and one authenticated
+  reserver `user`.
+- Active reservation state is derived from `cancelled_at IS NULL`.
+- A partial unique index restricts each wishlist item to at most one active
+  reservation while preserving canceled history.
 
 ## Planned Role
 - Model active reservation records for wishlist items.

--- a/src/modules/reservation/db/schema.ts
+++ b/src/modules/reservation/db/schema.ts
@@ -1,0 +1,32 @@
+import { sql } from "drizzle-orm";
+import { index, pgTable, timestamp, uniqueIndex, uuid } from "drizzle-orm/pg-core";
+import { users } from "@/modules/auth/db/schema";
+import { wishlistItems } from "@/modules/wishlist/db/schema";
+
+export const reservations = pgTable(
+  "reservations",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    wishlistItemId: uuid("wishlist_item_id")
+      .notNull()
+      .references(() => wishlistItems.id, { onDelete: "cascade" }),
+    userId: uuid("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    cancelledAt: timestamp("cancelled_at", { withTimezone: true }),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+  },
+  (table) => ({
+    wishlistItemIdIndex: index("reservations_wishlist_item_id_idx").on(
+      table.wishlistItemId,
+    ),
+    userIdIndex: index("reservations_user_id_idx").on(table.userId),
+    activeWishlistItemUniqueIndex: uniqueIndex(
+      "reservations_wishlist_item_id_active_unique",
+    )
+      .on(table.wishlistItemId)
+      .where(sql`${table.cancelledAt} IS NULL`),
+  }),
+);

--- a/src/modules/reservation/index.ts
+++ b/src/modules/reservation/index.ts
@@ -1,1 +1,1 @@
-export {};
+export { reservations } from "@/modules/reservation/db/schema";

--- a/src/shared/db/README.md
+++ b/src/shared/db/README.md
@@ -9,7 +9,8 @@
 ## Schema Layout
 - Module-owned schema files should live at `src/modules/<module>/db/schema.ts`
 - The current schema files live in `src/modules/auth/db/schema.ts`,
-  `src/modules/wishlist/db/schema.ts`, and `src/modules/share/db/schema.ts`
+  `src/modules/wishlist/db/schema.ts`, `src/modules/share/db/schema.ts`, and
+  `src/modules/reservation/db/schema.ts`
 - Auth schema starts with `users` and `sessions` only; keep auth runtime logic
   out of the DB foundation layer
 
@@ -28,6 +29,8 @@
   module for bootstrap, reads, and owner-scoped item mutations.
 - Share runtime logic now builds on these tables inside the `share` module for
   owner link lifecycle and public read-only loading.
+- Reservation schema now lives in `src/modules/reservation/db/schema.ts` with a
+  first-class `reservations` table for item-level reservation history.
 
 ## Wishlist Schema Foundation
 - `wishlists`: owner-linked wishlist records with `user_id`, `is_active`, and
@@ -42,9 +45,17 @@
 - The schema allows many historical links per wishlist while restricting each
   wishlist to one current active link.
 
+## Reservation Schema Foundation
+- `reservations`: item-linked reservation records with a reserver `user_id`,
+  `created_at`, and nullable `cancelled_at` lifecycle field.
+- Active reservation state is derived from `cancelled_at IS NULL` instead of an
+  item-level flag.
+- The schema allows many historical reservations per item while restricting
+  each item to one current active reservation.
+
 ## Next Expansion
-- The next DB expansion is expected in the `reservation` module for active
-  reservation records tied to wishlist items and authenticated reservers.
+- The next DB expansion is expected in the `reservation` module for lifecycle
+  helpers, reservation-aware reads, and reservation flows built on this schema.
 
 ## Environment Contract
 - `DATABASE_URL`: required PostgreSQL connection string

--- a/src/shared/db/client.ts
+++ b/src/shared/db/client.ts
@@ -1,6 +1,7 @@
 import { drizzle } from "drizzle-orm/node-postgres";
 import { Pool } from "pg";
 import * as authSchema from "@/modules/auth/db/schema";
+import * as reservationSchema from "@/modules/reservation/db/schema";
 import * as shareSchema from "@/modules/share/db/schema";
 import * as wishlistSchema from "@/modules/wishlist/db/schema";
 import { getDatabaseEnv } from "@/shared/db/env";
@@ -15,6 +16,7 @@ export const pool = new Pool({
 export const db = drizzle(pool, {
   schema: {
     ...authSchema,
+    ...reservationSchema,
     ...shareSchema,
     ...wishlistSchema,
   },


### PR DESCRIPTION
Closes #62 

Add the reservation database foundation for Milestone 5 so the project can support active reservation records, cancellation history, and one-active-reservation-per-item behavior without denormalizing reservation state into wishlist items.

## What changed

* added the `reservations` schema in the reservation module
* linked reservations to `wishlist_items` through `wishlist_item_id`
* linked reservations to `users` through `user_id`
* introduced lifecycle support through `cancelled_at`
* added a partial unique index so only one active reservation can exist for a wishlist item at a time
* added the generated Drizzle migration and updated migration metadata
* updated DB structure documentation for the new reservation foundation

## How to verify

* inspect `src/modules/reservation/db/schema.ts`
* confirm `reservations` is defined there
* confirm `reservations.wishlist_item_id` references `wishlist_items.id`
* confirm `reservations.user_id` references `users.id`
* confirm `cancelled_at` is used to represent inactive historical reservations
* inspect `drizzle/0003_reservation-schema-foundation.sql`
* confirm the migration creates the expected table, foreign keys, indexes, and partial unique index for active reservation uniqueness

## Tests

* `npm run typecheck`
* `npm run build`

## Documentation

* updated `src/shared/db/README.md`
* updated `src/modules/reservation/README.md`
* updated `src/README.md`
