### PR TITLE
feat(reservation): add lifecycle helpers

### DIFF
--- a/src/modules/reservation/README.md
+++ b/src/modules/reservation/README.md
@@ -3,6 +3,8 @@
 ## Current State
 - `src/modules/reservation/db/schema.ts` now owns the reservation DB
   foundation.
+- `src/modules/reservation/server/lifecycle.ts` now owns reservation helper and
+  lifecycle rule foundation.
 - `reservations` stores reservation history per wishlist item without adding
   reserved flags to `wishlist_items`.
 - `/app/reservations` still exists as a protected route placeholder for a later
@@ -14,6 +16,15 @@
 - Active reservation state is derived from `cancelled_at IS NULL`.
 - A partial unique index restricts each wishlist item to at most one active
   reservation while preserving canceled history.
+
+## Helper Foundation
+- `getActiveReservationByItemId(...)` reads the current active reservation for
+  one item.
+- `getItemReservationAvailability(...)` and
+  `getItemReservationEligibility(...)` centralize availability and ownership
+  checks for future route-level flows.
+- `createReservation(...)` and `cancelReservation(...)` enforce the minimal
+  lifecycle rules inside the module layer.
 
 ## Planned Role
 - Model active reservation records for wishlist items.

--- a/src/modules/reservation/server/index.ts
+++ b/src/modules/reservation/server/index.ts
@@ -1,4 +1,3 @@
-export { reservations } from "@/modules/reservation/db/schema";
 export {
   type ActiveReservation,
   type CancelReservationResult,
@@ -10,4 +9,4 @@ export {
   getActiveReservationByItemId,
   getItemReservationAvailability,
   getItemReservationEligibility,
-} from "@/modules/reservation/server";
+} from "@/modules/reservation/server/lifecycle";

--- a/src/modules/reservation/server/lifecycle.ts
+++ b/src/modules/reservation/server/lifecycle.ts
@@ -1,0 +1,300 @@
+import { and, asc, eq, isNull } from "drizzle-orm";
+import { DatabaseError } from "pg";
+import { reservations } from "@/modules/reservation/db/schema";
+import { wishlistItems, wishlists } from "@/modules/wishlist/db/schema";
+
+export type ActiveReservation = {
+  id: string;
+  wishlistItemId: string;
+  userId: string;
+  cancelledAt: null;
+  createdAt: Date;
+};
+
+export type ReservationAvailability =
+  | { status: "available" }
+  | {
+      status: "unavailable";
+      code: "item-not-found" | "already-reserved";
+    };
+
+export type ReservationEligibility =
+  | { status: "eligible" }
+  | {
+      status: "ineligible";
+      code: "item-not-found" | "already-reserved" | "own-item";
+    };
+
+export type CreateReservationResult =
+  | {
+      status: "success";
+      reservation: ActiveReservation;
+    }
+  | {
+      status: "error";
+      code: "item-not-found" | "already-reserved" | "own-item" | "unknown";
+    };
+
+export type CancelReservationResult =
+  | { status: "success" }
+  | {
+      status: "error";
+      code: "reservation-not-found" | "not-reservation-owner" | "unknown";
+    };
+
+type ReservationRecord = {
+  id: string;
+  wishlistItemId: string;
+  userId: string;
+  cancelledAt: Date | null;
+  createdAt: Date;
+};
+
+type ReservationItemContext = {
+  itemId: string;
+  wishlistId: string;
+  ownerUserId: string;
+};
+
+export async function getActiveReservationByItemId(itemId: string): Promise<ActiveReservation | null> {
+  const normalizedItemId = itemId.trim();
+
+  if (!normalizedItemId) {
+    return null;
+  }
+
+  const db = await getDb();
+  const activeReservation = await db.query.reservations.findFirst({
+    columns: {
+      id: true,
+      wishlistItemId: true,
+      userId: true,
+      cancelledAt: true,
+      createdAt: true,
+    },
+    where: and(
+      eq(reservations.wishlistItemId, normalizedItemId),
+      isNull(reservations.cancelledAt),
+    ),
+    orderBy: [asc(reservations.createdAt), asc(reservations.id)],
+  });
+
+  if (!activeReservation || activeReservation.cancelledAt !== null) {
+    return null;
+  }
+
+  return toActiveReservation(activeReservation);
+}
+
+export async function getItemReservationAvailability(
+  itemId: string,
+): Promise<ReservationAvailability> {
+  const itemContext = await findReservationItemContext(itemId);
+
+  if (!itemContext) {
+    return { status: "unavailable", code: "item-not-found" };
+  }
+
+  const activeReservation = await getActiveReservationByItemId(itemContext.itemId);
+
+  if (activeReservation) {
+    return { status: "unavailable", code: "already-reserved" };
+  }
+
+  return { status: "available" };
+}
+
+export async function getItemReservationEligibility(
+  userId: string,
+  itemId: string,
+): Promise<ReservationEligibility> {
+  const itemContext = await findReservationItemContext(itemId);
+
+  if (!itemContext) {
+    return { status: "ineligible", code: "item-not-found" };
+  }
+
+  if (itemContext.ownerUserId === userId) {
+    return { status: "ineligible", code: "own-item" };
+  }
+
+  const activeReservation = await getActiveReservationByItemId(itemContext.itemId);
+
+  if (activeReservation) {
+    return { status: "ineligible", code: "already-reserved" };
+  }
+
+  return { status: "eligible" };
+}
+
+export async function createReservation(
+  userId: string,
+  itemId: string,
+): Promise<CreateReservationResult> {
+  try {
+    const itemContext = await findReservationItemContext(itemId);
+
+    if (!itemContext) {
+      return { status: "error", code: "item-not-found" };
+    }
+
+    if (itemContext.ownerUserId === userId) {
+      return { status: "error", code: "own-item" };
+    }
+
+    const activeReservation = await getActiveReservationByItemId(itemContext.itemId);
+
+    if (activeReservation) {
+      return { status: "error", code: "already-reserved" };
+    }
+
+    const db = await getDb();
+    const [createdReservation] = await db
+      .insert(reservations)
+      .values({
+        wishlistItemId: itemContext.itemId,
+        userId,
+      })
+      .returning({
+        id: reservations.id,
+        wishlistItemId: reservations.wishlistItemId,
+        userId: reservations.userId,
+        cancelledAt: reservations.cancelledAt,
+        createdAt: reservations.createdAt,
+      });
+
+    if (!createdReservation || createdReservation.cancelledAt !== null) {
+      return { status: "error", code: "unknown" };
+    }
+
+    return {
+      status: "success",
+      reservation: toActiveReservation(createdReservation),
+    };
+  } catch (error) {
+    if (isUniqueViolation(error)) {
+      return { status: "error", code: "already-reserved" };
+    }
+
+    return { status: "error", code: "unknown" };
+  }
+}
+
+export async function cancelReservation(
+  userId: string,
+  reservationId: string,
+): Promise<CancelReservationResult> {
+  try {
+    const currentReservation = await findReservationById(reservationId);
+
+    if (!currentReservation || currentReservation.cancelledAt !== null) {
+      return { status: "error", code: "reservation-not-found" };
+    }
+
+    if (currentReservation.userId !== userId) {
+      return { status: "error", code: "not-reservation-owner" };
+    }
+
+    const db = await getDb();
+    const cancelledReservations = await db
+      .update(reservations)
+      .set({
+        cancelledAt: new Date(),
+      })
+      .where(
+        and(
+          eq(reservations.id, currentReservation.id),
+          eq(reservations.userId, userId),
+          isNull(reservations.cancelledAt),
+        ),
+      )
+      .returning({ id: reservations.id });
+
+    if (cancelledReservations.length === 0) {
+      return { status: "error", code: "reservation-not-found" };
+    }
+
+    return { status: "success" };
+  } catch {
+    return { status: "error", code: "unknown" };
+  }
+}
+
+async function findReservationItemContext(itemId: string): Promise<ReservationItemContext | null> {
+  const normalizedItemId = itemId.trim();
+
+  if (!normalizedItemId) {
+    return null;
+  }
+
+  const db = await getDb();
+  const item = await db.query.wishlistItems.findFirst({
+    columns: {
+      id: true,
+      wishlistId: true,
+    },
+    where: eq(wishlistItems.id, normalizedItemId),
+  });
+
+  if (!item) {
+    return null;
+  }
+
+  const wishlist = await db.query.wishlists.findFirst({
+    columns: {
+      id: true,
+      userId: true,
+    },
+    where: eq(wishlists.id, item.wishlistId),
+  });
+
+  if (!wishlist) {
+    return null;
+  }
+
+  return {
+    itemId: item.id,
+    wishlistId: wishlist.id,
+    ownerUserId: wishlist.userId,
+  };
+}
+
+async function findReservationById(reservationId: string): Promise<ReservationRecord | null> {
+  const normalizedReservationId = reservationId.trim();
+
+  if (!normalizedReservationId) {
+    return null;
+  }
+
+  const db = await getDb();
+
+  return (
+    (await db.query.reservations.findFirst({
+      columns: {
+        id: true,
+        wishlistItemId: true,
+        userId: true,
+        cancelledAt: true,
+        createdAt: true,
+      },
+      where: eq(reservations.id, normalizedReservationId),
+    })) ?? null
+  );
+}
+
+function isUniqueViolation(error: unknown): boolean {
+  return error instanceof DatabaseError && error.code === "23505";
+}
+
+function toActiveReservation(reservation: ReservationRecord): ActiveReservation {
+  return {
+    ...reservation,
+    cancelledAt: null,
+  };
+}
+
+async function getDb() {
+  const { db } = await import("@/shared/db");
+
+  return db;
+}

--- a/tests/unit/reservation-lifecycle.test.ts
+++ b/tests/unit/reservation-lifecycle.test.ts
@@ -1,0 +1,223 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { DatabaseError } from "pg";
+
+const mocks = vi.hoisted(() => ({
+  findReservation: vi.fn(),
+  findWishlistItem: vi.fn(),
+  findWishlist: vi.fn(),
+  insert: vi.fn(),
+  insertValues: vi.fn(),
+  insertReturning: vi.fn(),
+  update: vi.fn(),
+  updateSet: vi.fn(),
+  updateWhere: vi.fn(),
+  updateReturning: vi.fn(),
+}));
+
+vi.mock("../../src/shared/db", () => ({
+  db: {
+    query: {
+      reservations: {
+        findFirst: mocks.findReservation,
+      },
+      wishlistItems: {
+        findFirst: mocks.findWishlistItem,
+      },
+      wishlists: {
+        findFirst: mocks.findWishlist,
+      },
+    },
+    insert: mocks.insert,
+    update: mocks.update,
+  },
+}));
+
+import {
+  cancelReservation,
+  createReservation,
+  getActiveReservationByItemId,
+  getItemReservationAvailability,
+  getItemReservationEligibility,
+} from "../../src/modules/reservation/server/lifecycle";
+
+describe("reservation lifecycle helpers", () => {
+  beforeEach(() => {
+    mocks.findReservation.mockReset();
+    mocks.findWishlistItem.mockReset();
+    mocks.findWishlist.mockReset();
+    mocks.insert.mockReset();
+    mocks.insertValues.mockReset();
+    mocks.insertReturning.mockReset();
+    mocks.update.mockReset();
+    mocks.updateSet.mockReset();
+    mocks.updateWhere.mockReset();
+    mocks.updateReturning.mockReset();
+
+    mocks.insert.mockReturnValue({
+      values: mocks.insertValues,
+    });
+    mocks.insertValues.mockReturnValue({
+      returning: mocks.insertReturning,
+    });
+    mocks.update.mockReturnValue({
+      set: mocks.updateSet,
+    });
+    mocks.updateSet.mockReturnValue({
+      where: mocks.updateWhere,
+    });
+    mocks.updateWhere.mockReturnValue({
+      returning: mocks.updateReturning,
+    });
+    mocks.updateReturning.mockResolvedValue([]);
+  });
+
+  it("returns null for a blank active reservation lookup", async () => {
+    await expect(getActiveReservationByItemId("   ")).resolves.toBeNull();
+    expect(mocks.findReservation).not.toHaveBeenCalled();
+  });
+
+  it("reports item-not-found when reservation availability has no item context", async () => {
+    mocks.findWishlistItem.mockResolvedValue(undefined);
+
+    await expect(getItemReservationAvailability("item-1")).resolves.toEqual({
+      status: "unavailable",
+      code: "item-not-found",
+    });
+    expect(mocks.findReservation).not.toHaveBeenCalled();
+  });
+
+  it("blocks the owner from reserving their own item", async () => {
+    mocks.findWishlistItem.mockResolvedValue({
+      id: "item-1",
+      wishlistId: "wishlist-1",
+    });
+    mocks.findWishlist.mockResolvedValue({
+      id: "wishlist-1",
+      userId: "owner-1",
+    });
+
+    await expect(getItemReservationEligibility("owner-1", "item-1")).resolves.toEqual({
+      status: "ineligible",
+      code: "own-item",
+    });
+    expect(mocks.findReservation).not.toHaveBeenCalled();
+  });
+
+  it("creates a reservation for an eligible non-owner item", async () => {
+    const createdAt = new Date("2026-04-12T00:00:00.000Z");
+
+    mocks.findWishlistItem.mockResolvedValue({
+      id: "item-1",
+      wishlistId: "wishlist-1",
+    });
+    mocks.findWishlist.mockResolvedValue({
+      id: "wishlist-1",
+      userId: "owner-1",
+    });
+    mocks.findReservation.mockResolvedValue(undefined);
+    mocks.insertReturning.mockResolvedValue([
+      {
+        id: "reservation-1",
+        wishlistItemId: "item-1",
+        userId: "user-2",
+        cancelledAt: null,
+        createdAt,
+      },
+    ]);
+
+    await expect(createReservation("user-2", "item-1")).resolves.toEqual({
+      status: "success",
+      reservation: {
+        id: "reservation-1",
+        wishlistItemId: "item-1",
+        userId: "user-2",
+        cancelledAt: null,
+        createdAt,
+      },
+    });
+    expect(mocks.insertValues).toHaveBeenCalledWith({
+      wishlistItemId: "item-1",
+      userId: "user-2",
+    });
+  });
+
+  it("returns already-reserved when the item already has an active reservation", async () => {
+    mocks.findWishlistItem.mockResolvedValue({
+      id: "item-1",
+      wishlistId: "wishlist-1",
+    });
+    mocks.findWishlist.mockResolvedValue({
+      id: "wishlist-1",
+      userId: "owner-1",
+    });
+    mocks.findReservation.mockResolvedValue({
+      id: "reservation-1",
+      wishlistItemId: "item-1",
+      userId: "user-3",
+      cancelledAt: null,
+      createdAt: new Date("2026-04-12T00:00:00.000Z"),
+    });
+
+    await expect(createReservation("user-2", "item-1")).resolves.toEqual({
+      status: "error",
+      code: "already-reserved",
+    });
+    expect(mocks.insert).not.toHaveBeenCalled();
+  });
+
+  it("returns already-reserved when create races with another active reservation", async () => {
+    const duplicateKeyError = new DatabaseError("duplicate key", 0, "error");
+    duplicateKeyError.code = "23505";
+
+    mocks.findWishlistItem.mockResolvedValue({
+      id: "item-1",
+      wishlistId: "wishlist-1",
+    });
+    mocks.findWishlist.mockResolvedValue({
+      id: "wishlist-1",
+      userId: "owner-1",
+    });
+    mocks.findReservation.mockResolvedValue(undefined);
+    mocks.insertReturning.mockRejectedValue(duplicateKeyError);
+
+    await expect(createReservation("user-2", "item-1")).resolves.toEqual({
+      status: "error",
+      code: "already-reserved",
+    });
+  });
+
+  it("allows only the reservation owner to cancel an active reservation", async () => {
+    mocks.findReservation.mockResolvedValue({
+      id: "reservation-1",
+      wishlistItemId: "item-1",
+      userId: "user-2",
+      cancelledAt: null,
+      createdAt: new Date("2026-04-12T00:00:00.000Z"),
+    });
+    mocks.updateReturning.mockResolvedValue([{ id: "reservation-1" }]);
+
+    await expect(cancelReservation("user-2", "reservation-1")).resolves.toEqual({
+      status: "success",
+    });
+    expect(mocks.update).toHaveBeenCalledTimes(1);
+    expect(mocks.updateSet).toHaveBeenCalledWith({
+      cancelledAt: expect.any(Date),
+    });
+  });
+
+  it("rejects cancellation by a different user", async () => {
+    mocks.findReservation.mockResolvedValue({
+      id: "reservation-1",
+      wishlistItemId: "item-1",
+      userId: "user-2",
+      cancelledAt: null,
+      createdAt: new Date("2026-04-12T00:00:00.000Z"),
+    });
+
+    await expect(cancelReservation("user-3", "reservation-1")).resolves.toEqual({
+      status: "error",
+      code: "not-reservation-owner",
+    });
+    expect(mocks.update).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Closes #63 

Add the reservation lifecycle helper foundation so upcoming Milestone 5 PRs can build public reserve flow, owner reserved-state rendering, and reservation cancellation on top of one small server-side rules layer instead of duplicating business logic in routes.

## What changed

- added reservation lifecycle helpers under `src/modules/reservation/server/lifecycle.ts`
- added `getActiveReservationByItemId(itemId)` for active reservation lookup
- added `getItemReservationAvailability(itemId)` for non-user-specific availability checks
- added `getItemReservationEligibility(userId, itemId)` for user-aware reservation eligibility rules
- added `createReservation(userId, itemId)` for owner-safe reservation creation
- added `cancelReservation(userId, reservationId)` for reservation-owner-only cancellation
- kept active reservation state derived from reservation records where `cancelled_at IS NULL`
- handled create-time uniqueness races by translating DB conflicts into predictable reservation outcomes
- exported the new reservation lifecycle helpers through module entry points
- documented the lifecycle foundation in the reservation module docs

## How to verify

- inspect `src/modules/reservation/server/lifecycle.ts`
- confirm active reservation lookup is based on active reservation records rather than item flags
- confirm owner users cannot reserve their own wishlist items
- confirm reservation creation fails when an item already has an active reservation
- confirm reservation creation handles uniqueness races predictably
- confirm cancellation is allowed only for the user who created the active reservation
- confirm no UI routes, public page rendering, or `/app/reservations` behavior were added in this PR

## Tests

- `npm run typecheck`
- `npx vitest run tests/unit/reservation-lifecycle.test.ts`
- `npm run build`

## Documentation

- updated `src/modules/reservation/README.md`