### PR TITLE
feat(share): add public reservation state

### DIFF
--- a/src/modules/reservation/index.ts
+++ b/src/modules/reservation/index.ts
@@ -10,4 +10,5 @@ export {
   getActiveReservationByItemId,
   getItemReservationAvailability,
   getItemReservationEligibility,
+  listActiveReservationsByItemIds,
 } from "@/modules/reservation/server";

--- a/src/modules/reservation/server/index.ts
+++ b/src/modules/reservation/server/index.ts
@@ -9,4 +9,5 @@ export {
   getActiveReservationByItemId,
   getItemReservationAvailability,
   getItemReservationEligibility,
+  listActiveReservationsByItemIds,
 } from "@/modules/reservation/server/lifecycle";

--- a/src/modules/reservation/server/lifecycle.ts
+++ b/src/modules/reservation/server/lifecycle.ts
@@ -1,4 +1,4 @@
-import { and, asc, eq, isNull } from "drizzle-orm";
+import { and, asc, eq, inArray, isNull } from "drizzle-orm";
 import { DatabaseError } from "pg";
 import { reservations } from "@/modules/reservation/db/schema";
 import { wishlistItems, wishlists } from "@/modules/wishlist/db/schema";
@@ -84,6 +84,38 @@ export async function getActiveReservationByItemId(itemId: string): Promise<Acti
   }
 
   return toActiveReservation(activeReservation);
+}
+
+export async function listActiveReservationsByItemIds(
+  itemIds: string[],
+): Promise<ActiveReservation[]> {
+  const normalizedItemIds = Array.from(
+    new Set(itemIds.map((itemId) => itemId.trim()).filter(Boolean)),
+  );
+
+  if (normalizedItemIds.length === 0) {
+    return [];
+  }
+
+  const db = await getDb();
+  const activeReservations = await db.query.reservations.findMany({
+    columns: {
+      id: true,
+      wishlistItemId: true,
+      userId: true,
+      cancelledAt: true,
+      createdAt: true,
+    },
+    where: and(
+      inArray(reservations.wishlistItemId, normalizedItemIds),
+      isNull(reservations.cancelledAt),
+    ),
+    orderBy: [asc(reservations.createdAt), asc(reservations.id)],
+  });
+
+  return activeReservations
+    .filter((reservation) => reservation.cancelledAt === null)
+    .map(toActiveReservation);
 }
 
 export async function getItemReservationAvailability(

--- a/src/modules/share/README.md
+++ b/src/modules/share/README.md
@@ -7,7 +7,8 @@
 - `server/current-share-link.ts`: owner-side current-link read, create, revoke,
   and regenerate helpers for the current wishlist.
 - `server/public-wishlist.ts`: public loading helpers that resolve an active
-  share token to a read-only wishlist with ordered items.
+  share token to a read-only wishlist with ordered items and privacy-safe
+  reservation state.
 
 ## Current Behavior
 - `/app` shows the owner a share section for the current wishlist.
@@ -16,6 +17,8 @@
 - `/share/[token]` renders a public read-only wishlist for valid active tokens.
 - Invalid, inactive, revoked, and superseded tokens do not expose wishlist
   data.
+- Public item read models expose only `available` or `reserved` state without
+  reserver identity.
 
 ## Test Coverage
 - Unit and integration-like tests cover token generation, owner lifecycle

--- a/src/modules/share/index.ts
+++ b/src/modules/share/index.ts
@@ -1,12 +1,15 @@
 export { shareLinks } from "@/modules/share/db/schema";
 export {
   type CurrentShareLink,
+  type PublicWishlistItem,
+  type PublicWishlistItemReservation,
   type PublicWishlist,
   generateShareToken,
   getActiveShareLinkByToken,
   getCurrentShareLink,
   getOrCreateCurrentShareLink,
   getPublicWishlistByShareToken,
+  getReservationAwarePublicWishlistByShareToken,
   regenerateCurrentShareLink,
   revokeCurrentShareLink,
 } from "@/modules/share/server";

--- a/src/modules/share/server/index.ts
+++ b/src/modules/share/server/index.ts
@@ -6,8 +6,11 @@ export {
   revokeCurrentShareLink,
 } from "@/modules/share/server/current-share-link";
 export {
+  type PublicWishlistItem,
+  type PublicWishlistItemReservation,
   type PublicWishlist,
   getActiveShareLinkByToken,
   getPublicWishlistByShareToken,
+  getReservationAwarePublicWishlistByShareToken,
 } from "@/modules/share/server/public-wishlist";
 export { generateShareToken } from "@/modules/share/server/token";

--- a/src/modules/share/server/public-wishlist.ts
+++ b/src/modules/share/server/public-wishlist.ts
@@ -1,4 +1,5 @@
 import { and, eq } from "drizzle-orm";
+import { listActiveReservationsByItemIds } from "@/modules/reservation";
 import { shareLinks } from "@/modules/share/db/schema";
 import { type CurrentShareLink } from "@/modules/share/server/current-share-link";
 import {
@@ -6,9 +7,17 @@ import {
   type WishlistItemRecord,
 } from "@/modules/wishlist/server/items";
 
+export type PublicWishlistItemReservation = {
+  status: "available" | "reserved";
+};
+
+export type PublicWishlistItem = WishlistItemRecord & {
+  reservation: PublicWishlistItemReservation;
+};
+
 export type PublicWishlist = {
   id: string;
-  items: WishlistItemRecord[];
+  items: PublicWishlistItem[];
   shareLink: {
     id: string;
     token: string;
@@ -40,6 +49,12 @@ export async function getActiveShareLinkByToken(token: string): Promise<CurrentS
 }
 
 export async function getPublicWishlistByShareToken(token: string): Promise<PublicWishlist | null> {
+  return getReservationAwarePublicWishlistByShareToken(token);
+}
+
+export async function getReservationAwarePublicWishlistByShareToken(
+  token: string,
+): Promise<PublicWishlist | null> {
   const shareLink = await getActiveShareLinkByToken(token);
 
   if (!shareLink) {
@@ -52,14 +67,36 @@ export async function getPublicWishlistByShareToken(token: string): Promise<Publ
     return null;
   }
 
+  const activeReservationItemIds = new Set(
+    (await listActiveReservationsByItemIds(wishlist.items.map((item) => item.id))).map(
+      (reservation) => reservation.wishlistItemId,
+    ),
+  );
+
+  const items = wishlist.items.map((item) => ({
+    ...item,
+    reservation: getPublicWishlistItemReservation(item.id, activeReservationItemIds),
+  }));
+
   return {
     id: wishlist.id,
-    items: wishlist.items,
+    items,
     shareLink: {
       id: shareLink.id,
       token: shareLink.token,
     },
   };
+}
+
+function getPublicWishlistItemReservation(
+  itemId: string,
+  activeReservationItemIds: Set<string>,
+): PublicWishlistItemReservation {
+  if (activeReservationItemIds.has(itemId)) {
+    return { status: "reserved" };
+  }
+
+  return { status: "available" };
 }
 
 async function getDb() {

--- a/tests/unit/reservation-lifecycle.test.ts
+++ b/tests/unit/reservation-lifecycle.test.ts
@@ -3,6 +3,7 @@ import { DatabaseError } from "pg";
 
 const mocks = vi.hoisted(() => ({
   findReservation: vi.fn(),
+  findReservations: vi.fn(),
   findWishlistItem: vi.fn(),
   findWishlist: vi.fn(),
   insert: vi.fn(),
@@ -19,6 +20,7 @@ vi.mock("../../src/shared/db", () => ({
     query: {
       reservations: {
         findFirst: mocks.findReservation,
+        findMany: mocks.findReservations,
       },
       wishlistItems: {
         findFirst: mocks.findWishlistItem,
@@ -38,11 +40,13 @@ import {
   getActiveReservationByItemId,
   getItemReservationAvailability,
   getItemReservationEligibility,
+  listActiveReservationsByItemIds,
 } from "../../src/modules/reservation/server/lifecycle";
 
 describe("reservation lifecycle helpers", () => {
   beforeEach(() => {
     mocks.findReservation.mockReset();
+    mocks.findReservations.mockReset();
     mocks.findWishlistItem.mockReset();
     mocks.findWishlist.mockReset();
     mocks.insert.mockReset();
@@ -74,6 +78,32 @@ describe("reservation lifecycle helpers", () => {
   it("returns null for a blank active reservation lookup", async () => {
     await expect(getActiveReservationByItemId("   ")).resolves.toBeNull();
     expect(mocks.findReservation).not.toHaveBeenCalled();
+  });
+
+  it("loads active reservations for multiple item ids in one batch", async () => {
+    const createdAt = new Date("2026-04-12T00:00:00.000Z");
+
+    mocks.findReservations.mockResolvedValue([
+      {
+        id: "reservation-1",
+        wishlistItemId: "item-1",
+        userId: "user-2",
+        cancelledAt: null,
+        createdAt,
+      },
+    ]);
+
+    await expect(listActiveReservationsByItemIds(["item-1", " item-1 ", "item-2"]))
+      .resolves.toEqual([
+        {
+          id: "reservation-1",
+          wishlistItemId: "item-1",
+          userId: "user-2",
+          cancelledAt: null,
+          createdAt,
+        },
+      ]);
+    expect(mocks.findReservations).toHaveBeenCalledTimes(1);
   });
 
   it("reports item-not-found when reservation availability has no item context", async () => {

--- a/tests/unit/share-public-wishlist.test.ts
+++ b/tests/unit/share-public-wishlist.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const mocks = vi.hoisted(() => ({
   findShareLink: vi.fn(),
   getWishlistWithItems: vi.fn(),
+  listActiveReservationsByItemIds: vi.fn(),
 }));
 
 vi.mock("../../src/shared/db", () => ({
@@ -19,15 +20,21 @@ vi.mock("../../src/modules/wishlist/server/items", () => ({
   getWishlistWithItems: mocks.getWishlistWithItems,
 }));
 
+vi.mock("../../src/modules/reservation", () => ({
+  listActiveReservationsByItemIds: mocks.listActiveReservationsByItemIds,
+}));
+
 import {
   getActiveShareLinkByToken,
   getPublicWishlistByShareToken,
+  getReservationAwarePublicWishlistByShareToken,
 } from "../../src/modules/share/server/public-wishlist";
 
 describe("public wishlist loading by share token", () => {
   beforeEach(() => {
     mocks.findShareLink.mockReset();
     mocks.getWishlistWithItems.mockReset();
+    mocks.listActiveReservationsByItemIds.mockReset();
   });
 
   it("returns null for a missing token", async () => {
@@ -113,6 +120,7 @@ describe("public wishlist loading by share token", () => {
         },
       ],
     });
+    mocks.listActiveReservationsByItemIds.mockResolvedValue([]);
 
     await expect(getPublicWishlistByShareToken("opaque-token")).resolves.toEqual({
       id: "wishlist-1",
@@ -126,6 +134,9 @@ describe("public wishlist loading by share token", () => {
           price: "9990.00",
           createdAt: new Date("2026-04-11T00:00:00.000Z"),
           updatedAt: new Date("2026-04-11T00:00:00.000Z"),
+          reservation: {
+            status: "available",
+          },
         },
       ],
       shareLink: {
@@ -133,6 +144,92 @@ describe("public wishlist loading by share token", () => {
         token: "opaque-token",
       },
     });
+  });
+
+  it("loads reservation-aware public item state without exposing reserver identity", async () => {
+    mocks.findShareLink.mockResolvedValue({
+      id: "share-1",
+      wishlistId: "wishlist-1",
+      token: "opaque-token",
+      isActive: true,
+      createdAt: new Date("2026-04-12T00:00:00.000Z"),
+      updatedAt: new Date("2026-04-12T00:00:00.000Z"),
+    });
+    mocks.getWishlistWithItems.mockResolvedValue({
+      id: "wishlist-1",
+      userId: "owner-1",
+      isActive: true,
+      createdAt: new Date("2026-04-11T00:00:00.000Z"),
+      updatedAt: new Date("2026-04-11T00:00:00.000Z"),
+      items: [
+        {
+          id: "item-1",
+          wishlistId: "wishlist-1",
+          title: "Наушники",
+          url: null,
+          note: null,
+          price: null,
+          createdAt: new Date("2026-04-11T00:00:00.000Z"),
+          updatedAt: new Date("2026-04-11T00:00:00.000Z"),
+        },
+        {
+          id: "item-2",
+          wishlistId: "wishlist-1",
+          title: "Книга",
+          url: null,
+          note: null,
+          price: null,
+          createdAt: new Date("2026-04-11T00:00:00.000Z"),
+          updatedAt: new Date("2026-04-11T00:00:00.000Z"),
+        },
+      ],
+    });
+    mocks.listActiveReservationsByItemIds.mockResolvedValue([
+      {
+        id: "reservation-1",
+        wishlistItemId: "item-1",
+        userId: "user-2",
+        cancelledAt: null,
+        createdAt: new Date("2026-04-12T00:00:00.000Z"),
+      },
+    ]);
+
+    await expect(getReservationAwarePublicWishlistByShareToken("opaque-token")).resolves.toEqual({
+      id: "wishlist-1",
+      items: [
+        {
+          id: "item-1",
+          wishlistId: "wishlist-1",
+          title: "Наушники",
+          url: null,
+          note: null,
+          price: null,
+          createdAt: new Date("2026-04-11T00:00:00.000Z"),
+          updatedAt: new Date("2026-04-11T00:00:00.000Z"),
+          reservation: {
+            status: "reserved",
+          },
+        },
+        {
+          id: "item-2",
+          wishlistId: "wishlist-1",
+          title: "Книга",
+          url: null,
+          note: null,
+          price: null,
+          createdAt: new Date("2026-04-11T00:00:00.000Z"),
+          updatedAt: new Date("2026-04-11T00:00:00.000Z"),
+          reservation: {
+            status: "available",
+          },
+        },
+      ],
+      shareLink: {
+        id: "share-1",
+        token: "opaque-token",
+      },
+    });
+    expect(mocks.listActiveReservationsByItemIds).toHaveBeenCalledWith(["item-1", "item-2"]);
   });
 
   it("loads only the new token after regeneration while the old token stays invalid", async () => {
@@ -154,6 +251,7 @@ describe("public wishlist loading by share token", () => {
       updatedAt: new Date("2026-04-11T00:00:00.000Z"),
       items: [],
     });
+    mocks.listActiveReservationsByItemIds.mockResolvedValue([]);
 
     await expect(getPublicWishlistByShareToken("old-token")).resolves.toBeNull();
     await expect(getPublicWishlistByShareToken("new-token")).resolves.toEqual({


### PR DESCRIPTION
Closes #64 

Add reservation-aware public wishlist loading so the public share flow can tell whether items are available or already reserved without exposing reserver identity or pushing reservation queries into the route layer. Keep the implementation server-side and privacy-safe by extending the existing share-module loading foundation rather than adding reserve actions or UI behavior in this PR.

## What changed

* extended public wishlist loading to include privacy-safe reservation state per item
* added a reservation-aware public loading helper in the share module
* kept invalid, inactive, and revoked token behavior unchanged
* preserved the existing public result shape while adding item-level reservation status
* added a batch reservation lookup helper to avoid per-item reservation queries
* mapped public item reservation state to read-only values:

  * `available`
  * `reserved`
* updated share and reservation module exports for the new loading foundation
* expanded focused tests for reservation-aware public loading behavior

## How to verify

* inspect `src/modules/share/server/public-wishlist.ts`
* confirm public loading still starts from a valid active share token
* confirm valid active tokens return wishlist items with privacy-safe reservation state
* confirm invalid, inactive, and revoked tokens still return no wishlist data
* confirm reserver identity is not exposed in the public result
* confirm reservation state is loaded in batch rather than by per-item queries
* confirm the existing `/share/[token]` route can continue using the public loading foundation without UI changes

## Tests

* `npm run typecheck`
* `npx vitest run tests/unit/share-public-wishlist.test.ts tests/unit/reservation-lifecycle.test.ts`
* `npm run build`

## Documentation

* no additional product or process documentation changes required for this PR
