### PR TITLE
test(reservation): cover milestone five flows

### DIFF
--- a/src/app/app/reservations/actions.ts
+++ b/src/app/app/reservations/actions.ts
@@ -1,0 +1,30 @@
+import { redirect } from "next/navigation";
+import { requireCurrentUser } from "@/modules/auth/server/current-user";
+import { cancelReservation } from "@/modules/reservation";
+
+export async function cancelReservationAction(formData: FormData) {
+  "use server";
+
+  const user = await requireCurrentUser();
+  const reservationId = getFormValue(formData, "reservationId");
+  const result = await cancelReservation(user.id, reservationId);
+
+  if (result.status === "success") {
+    redirect("/app/reservations?status=reservation-cancelled");
+  }
+
+  switch (result.code) {
+    case "not-reservation-owner":
+      redirect("/app/reservations?action=cancel&error=not-reservation-owner");
+    case "reservation-not-found":
+      redirect("/app/reservations?action=cancel&error=reservation-not-found");
+    default:
+      redirect("/app/reservations?action=cancel&error=unknown");
+  }
+}
+
+function getFormValue(formData: FormData, fieldName: string): string {
+  const value = formData.get(fieldName);
+
+  return typeof value === "string" ? value : "";
+}

--- a/src/app/app/reservations/page.tsx
+++ b/src/app/app/reservations/page.tsx
@@ -1,8 +1,8 @@
 import { requireCurrentUser } from "@/modules/auth/server/current-user";
 import { getTranslations } from "@/modules/i18n";
-import { cancelReservation, listCurrentUserActiveReservations } from "@/modules/reservation";
-import { redirect } from "next/navigation";
+import { listCurrentUserActiveReservations } from "@/modules/reservation";
 import { PageShell } from "@/shared/ui/page-shell";
+import { cancelReservationAction } from "@/app/app/reservations/actions";
 
 const common = getTranslations("common");
 const messages = getTranslations("app");
@@ -98,33 +98,6 @@ export default async function ReservationsPage(props: ReservationsPageProps) {
       )}
     </PageShell>
   );
-}
-
-async function cancelReservationAction(formData: FormData) {
-  "use server";
-
-  const user = await requireCurrentUser();
-  const reservationId = getFormValue(formData, "reservationId");
-  const result = await cancelReservation(user.id, reservationId);
-
-  if (result.status === "success") {
-    redirect("/app/reservations?status=reservation-cancelled");
-  }
-
-  switch (result.code) {
-    case "not-reservation-owner":
-      redirect("/app/reservations?action=cancel&error=not-reservation-owner");
-    case "reservation-not-found":
-      redirect("/app/reservations?action=cancel&error=reservation-not-found");
-    default:
-      redirect("/app/reservations?action=cancel&error=unknown");
-  }
-}
-
-function getFormValue(formData: FormData, fieldName: string): string {
-  const value = formData.get(fieldName);
-
-  return typeof value === "string" ? value : "";
 }
 
 function getReservationsActionErrorMessage(action: string | undefined, errorCode: string): string {

--- a/src/app/share/[token]/actions.ts
+++ b/src/app/share/[token]/actions.ts
@@ -1,0 +1,59 @@
+import { redirect } from "next/navigation";
+
+export async function reservePublicWishlistItemAction(formData: FormData) {
+  "use server";
+
+  const [{ getCurrentUser }, { createReservation }, { getPublicWishlistViewByShareToken }] =
+    await Promise.all([
+      import("@/modules/auth/server/current-user"),
+      import("@/modules/reservation/server/lifecycle"),
+      import("@/modules/share/server/public-wishlist"),
+    ]);
+  const user = await getCurrentUser();
+  const token = getFormValue(formData, "token").trim();
+  const itemId = getFormValue(formData, "itemId").trim();
+
+  if (!user) {
+    redirect("/login");
+  }
+
+  const sharePath = buildSharePath(token);
+  const publicWishlist = await getPublicWishlistViewByShareToken(token, user.id);
+
+  if (!publicWishlist) {
+    redirect(`${sharePath}?action=reserve&error=invalid-share`);
+  }
+
+  const matchingItem = publicWishlist.items.find((item) => item.id === itemId);
+
+  if (!matchingItem) {
+    redirect(`${sharePath}?action=reserve&error=invalid-share`);
+  }
+
+  const result = await createReservation(user.id, itemId);
+
+  if (result.status === "success") {
+    redirect(`${sharePath}?status=reservation-created`);
+  }
+
+  switch (result.code) {
+    case "already-reserved":
+      redirect(`${sharePath}?action=reserve&error=already-reserved`);
+    case "own-item":
+      redirect(`${sharePath}?action=reserve&error=own-item`);
+    case "item-not-found":
+      redirect(`${sharePath}?action=reserve&error=invalid-share`);
+    default:
+      redirect(`${sharePath}?action=reserve&error=unknown`);
+  }
+}
+
+function buildSharePath(token: string): string {
+  return `/share/${encodeURIComponent(token)}`;
+}
+
+function getFormValue(formData: FormData, fieldName: string): string {
+  const value = formData.get(fieldName);
+
+  return typeof value === "string" ? value : "";
+}

--- a/src/app/share/[token]/page.tsx
+++ b/src/app/share/[token]/page.tsx
@@ -1,7 +1,7 @@
 import Link from "next/link";
-import { redirect } from "next/navigation";
 import { getTranslations } from "@/modules/i18n";
 import { PageShell } from "@/shared/ui/page-shell";
+import { reservePublicWishlistItemAction } from "@/app/share/[token]/actions";
 
 const common = getTranslations("common");
 const messages = getTranslations("app");
@@ -133,64 +133,6 @@ export default async function SharePage(props: SharePageProps) {
       )}
     </PageShell>
   );
-}
-
-async function reservePublicWishlistItemAction(formData: FormData) {
-  "use server";
-
-  const [{ getCurrentUser }, { createReservation }, { getPublicWishlistViewByShareToken }] =
-    await Promise.all([
-      import("@/modules/auth/server/current-user"),
-      import("@/modules/reservation/server/lifecycle"),
-      import("@/modules/share/server/public-wishlist"),
-    ]);
-  const user = await getCurrentUser();
-  const token = getFormValue(formData, "token").trim();
-  const itemId = getFormValue(formData, "itemId").trim();
-
-  if (!user) {
-    redirect("/login");
-  }
-
-  const sharePath = buildSharePath(token);
-  const publicWishlist = await getPublicWishlistViewByShareToken(token, user.id);
-
-  if (!publicWishlist) {
-    redirect(`${sharePath}?action=reserve&error=invalid-share`);
-  }
-
-  const matchingItem = publicWishlist.items.find((item) => item.id === itemId);
-
-  if (!matchingItem) {
-    redirect(`${sharePath}?action=reserve&error=invalid-share`);
-  }
-
-  const result = await createReservation(user.id, itemId);
-
-  if (result.status === "success") {
-    redirect(`${sharePath}?status=reservation-created`);
-  }
-
-  switch (result.code) {
-    case "already-reserved":
-      redirect(`${sharePath}?action=reserve&error=already-reserved`);
-    case "own-item":
-      redirect(`${sharePath}?action=reserve&error=own-item`);
-    case "item-not-found":
-      redirect(`${sharePath}?action=reserve&error=invalid-share`);
-    default:
-      redirect(`${sharePath}?action=reserve&error=unknown`);
-  }
-}
-
-function buildSharePath(token: string): string {
-  return `/share/${encodeURIComponent(token)}`;
-}
-
-function getFormValue(formData: FormData, fieldName: string): string {
-  const value = formData.get(fieldName);
-
-  return typeof value === "string" ? value : "";
 }
 
 function getShareActionErrorMessage(action: string | undefined, errorCode: string): string {

--- a/tests/unit/reservation-current-user.test.ts
+++ b/tests/unit/reservation-current-user.test.ts
@@ -71,4 +71,17 @@ describe("current user active reservations loading", () => {
     await expect(listCurrentUserActiveReservations("user-1")).resolves.toEqual([]);
     expect(mocks.findWishlistItems).not.toHaveBeenCalled();
   });
+
+  it("does not return reservations whose linked active item data is missing", async () => {
+    mocks.findReservations.mockResolvedValue([
+      {
+        id: "reservation-1",
+        wishlistItemId: "missing-item",
+        createdAt: new Date("2026-04-12T00:00:00.000Z"),
+      },
+    ]);
+    mocks.findWishlistItems.mockResolvedValue([]);
+
+    await expect(listCurrentUserActiveReservations("user-1")).resolves.toEqual([]);
+  });
 });

--- a/tests/unit/reservation-lifecycle.test.ts
+++ b/tests/unit/reservation-lifecycle.test.ts
@@ -106,6 +106,18 @@ describe("reservation lifecycle helpers", () => {
     expect(mocks.findReservations).toHaveBeenCalledTimes(1);
   });
 
+  it("returns null when the existing reservation record is already canceled", async () => {
+    mocks.findReservation.mockResolvedValue({
+      id: "reservation-1",
+      wishlistItemId: "item-1",
+      userId: "user-2",
+      cancelledAt: new Date("2026-04-13T00:00:00.000Z"),
+      createdAt: new Date("2026-04-12T00:00:00.000Z"),
+    });
+
+    await expect(getActiveReservationByItemId("item-1")).resolves.toBeNull();
+  });
+
   it("reports item-not-found when reservation availability has no item context", async () => {
     mocks.findWishlistItem.mockResolvedValue(undefined);
 
@@ -114,6 +126,45 @@ describe("reservation lifecycle helpers", () => {
       code: "item-not-found",
     });
     expect(mocks.findReservation).not.toHaveBeenCalled();
+  });
+
+  it("reports already-reserved when reservation availability sees an active reservation", async () => {
+    mocks.findWishlistItem.mockResolvedValue({
+      id: "item-1",
+      wishlistId: "wishlist-1",
+    });
+    mocks.findWishlist.mockResolvedValue({
+      id: "wishlist-1",
+      userId: "owner-1",
+    });
+    mocks.findReservation.mockResolvedValue({
+      id: "reservation-1",
+      wishlistItemId: "item-1",
+      userId: "user-3",
+      cancelledAt: null,
+      createdAt: new Date("2026-04-12T00:00:00.000Z"),
+    });
+
+    await expect(getItemReservationAvailability("item-1")).resolves.toEqual({
+      status: "unavailable",
+      code: "already-reserved",
+    });
+  });
+
+  it("marks a non-owner as eligible when the item is available", async () => {
+    mocks.findWishlistItem.mockResolvedValue({
+      id: "item-1",
+      wishlistId: "wishlist-1",
+    });
+    mocks.findWishlist.mockResolvedValue({
+      id: "wishlist-1",
+      userId: "owner-1",
+    });
+    mocks.findReservation.mockResolvedValue(undefined);
+
+    await expect(getItemReservationEligibility("user-2", "item-1")).resolves.toEqual({
+      status: "eligible",
+    });
   });
 
   it("blocks the owner from reserving their own item", async () => {
@@ -169,6 +220,16 @@ describe("reservation lifecycle helpers", () => {
       wishlistItemId: "item-1",
       userId: "user-2",
     });
+  });
+
+  it("returns item-not-found when create reservation has no valid item context", async () => {
+    mocks.findWishlistItem.mockResolvedValue(undefined);
+
+    await expect(createReservation("user-2", "item-1")).resolves.toEqual({
+      status: "error",
+      code: "item-not-found",
+    });
+    expect(mocks.insert).not.toHaveBeenCalled();
   });
 
   it("returns already-reserved when the item already has an active reservation", async () => {
@@ -233,6 +294,16 @@ describe("reservation lifecycle helpers", () => {
     expect(mocks.updateSet).toHaveBeenCalledWith({
       cancelledAt: expect.any(Date),
     });
+  });
+
+  it("returns reservation-not-found when cancel target is missing or already inactive", async () => {
+    mocks.findReservation.mockResolvedValue(undefined);
+
+    await expect(cancelReservation("user-2", "reservation-1")).resolves.toEqual({
+      status: "error",
+      code: "reservation-not-found",
+    });
+    expect(mocks.update).not.toHaveBeenCalled();
   });
 
   it("rejects cancellation by a different user", async () => {

--- a/tests/unit/reservations-page.test.ts
+++ b/tests/unit/reservations-page.test.ts
@@ -5,10 +5,12 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const mocks = vi.hoisted(() => ({
   requireCurrentUser: vi.fn(),
   listCurrentUserActiveReservations: vi.fn(),
+  cancelReservation: vi.fn(),
+  redirect: vi.fn(),
 }));
 
 vi.mock("next/navigation", () => ({
-  redirect: vi.fn(),
+  redirect: mocks.redirect,
 }));
 
 vi.mock("../../src/modules/auth/server/current-user", () => ({
@@ -16,15 +18,25 @@ vi.mock("../../src/modules/auth/server/current-user", () => ({
 }));
 
 vi.mock("../../src/modules/reservation", () => ({
-  cancelReservation: vi.fn(),
+  cancelReservation: mocks.cancelReservation,
   listCurrentUserActiveReservations: mocks.listCurrentUserActiveReservations,
 }));
+
+function expectRedirectCall(run: () => Promise<unknown>, url: string) {
+  mocks.redirect.mockImplementationOnce((target: string) => {
+    throw new Error(`REDIRECT:${target}`);
+  });
+
+  return expect(run()).rejects.toThrow(`REDIRECT:${url}`);
+}
 
 describe("current user reservations page", () => {
   beforeEach(() => {
     Object.assign(globalThis, { React });
     mocks.requireCurrentUser.mockReset();
     mocks.listCurrentUserActiveReservations.mockReset();
+    mocks.cancelReservation.mockReset();
+    mocks.redirect.mockReset();
     mocks.requireCurrentUser.mockResolvedValue({
       id: "user-1",
       email: "user@example.com",
@@ -88,5 +100,45 @@ describe("current user reservations page", () => {
     expect(renderToStaticMarkup(errorPage)).toContain(
       "Можно отменить только свою активную бронь.",
     );
+  });
+
+  it("redirects after a successful cancel and blocks not-owner or missing reservations", async () => {
+    const { cancelReservationAction } = await import("../../src/app/app/reservations/actions");
+
+    const successFormData = new FormData();
+    successFormData.set("reservationId", "reservation-1");
+    mocks.cancelReservation.mockResolvedValueOnce({ status: "success" });
+
+    await expectRedirectCall(
+      () => cancelReservationAction(successFormData),
+      "/app/reservations?status=reservation-cancelled",
+    );
+
+    const notOwnerFormData = new FormData();
+    notOwnerFormData.set("reservationId", "reservation-2");
+    mocks.cancelReservation.mockResolvedValueOnce({
+      status: "error",
+      code: "not-reservation-owner",
+    });
+
+    await expectRedirectCall(
+      () => cancelReservationAction(notOwnerFormData),
+      "/app/reservations?action=cancel&error=not-reservation-owner",
+    );
+
+    const missingFormData = new FormData();
+    missingFormData.set("reservationId", "reservation-3");
+    mocks.cancelReservation.mockResolvedValueOnce({
+      status: "error",
+      code: "reservation-not-found",
+    });
+
+    await expectRedirectCall(
+      () => cancelReservationAction(missingFormData),
+      "/app/reservations?action=cancel&error=reservation-not-found",
+    );
+    expect(mocks.cancelReservation).toHaveBeenNthCalledWith(1, "user-1", "reservation-1");
+    expect(mocks.cancelReservation).toHaveBeenNthCalledWith(2, "user-1", "reservation-2");
+    expect(mocks.cancelReservation).toHaveBeenNthCalledWith(3, "user-1", "reservation-3");
   });
 });

--- a/tests/unit/share-page.test.ts
+++ b/tests/unit/share-page.test.ts
@@ -5,6 +5,12 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const mocks = vi.hoisted(() => ({
   getCurrentUser: vi.fn(),
   getPublicWishlistViewByShareToken: vi.fn(),
+  createReservation: vi.fn(),
+  redirect: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  redirect: mocks.redirect,
 }));
 
 vi.mock("../../src/modules/auth", () => ({
@@ -23,11 +29,25 @@ vi.mock("../../src/modules/share/server/public-wishlist", () => ({
   getPublicWishlistViewByShareToken: mocks.getPublicWishlistViewByShareToken,
 }));
 
+vi.mock("../../src/modules/reservation/server/lifecycle", () => ({
+  createReservation: mocks.createReservation,
+}));
+
+function expectRedirectCall(run: () => Promise<unknown>, url: string) {
+  mocks.redirect.mockImplementationOnce((target: string) => {
+    throw new Error(`REDIRECT:${target}`);
+  });
+
+  return expect(run()).rejects.toThrow(`REDIRECT:${url}`);
+}
+
 describe("public share route rendering", () => {
   beforeEach(() => {
     Object.assign(globalThis, { React });
     mocks.getCurrentUser.mockReset();
     mocks.getPublicWishlistViewByShareToken.mockReset();
+    mocks.createReservation.mockReset();
+    mocks.redirect.mockReset();
     mocks.getCurrentUser.mockResolvedValue(null);
   });
 
@@ -285,5 +305,141 @@ describe("public share route rendering", () => {
 
     expect(renderToStaticMarkup(successPage)).toContain("Желание забронировано.");
     expect(renderToStaticMarkup(errorPage)).toContain("Это желание уже забронировано.");
+  });
+
+  it("redirects guests to login when reserve action is submitted", async () => {
+    const { reservePublicWishlistItemAction } = await import("../../src/app/share/[token]/actions");
+    const formData = new FormData();
+    formData.set("token", "opaque-token");
+    formData.set("itemId", "item-1");
+
+    await expectRedirectCall(() => reservePublicWishlistItemAction(formData), "/login");
+    expect(mocks.getPublicWishlistViewByShareToken).not.toHaveBeenCalled();
+    expect(mocks.createReservation).not.toHaveBeenCalled();
+  });
+
+  it("creates a reservation for an eligible authenticated non-owner", async () => {
+    mocks.getCurrentUser.mockResolvedValue({
+      id: "user-2",
+      email: "user@example.com",
+    });
+    mocks.getPublicWishlistViewByShareToken.mockResolvedValue({
+      id: "wishlist-1",
+      items: [
+        {
+          id: "item-1",
+          wishlistId: "wishlist-1",
+          title: "Наушники",
+          url: null,
+          note: null,
+          price: null,
+          createdAt: new Date("2026-04-11T00:00:00.000Z"),
+          updatedAt: new Date("2026-04-11T00:00:00.000Z"),
+          reservation: { status: "available" },
+        },
+      ],
+      shareLink: { id: "share-1", token: "opaque-token" },
+      viewer: { isAuthenticated: true, isOwner: false },
+    });
+    mocks.createReservation.mockResolvedValue({
+      status: "success",
+      reservation: {
+        id: "reservation-1",
+        wishlistItemId: "item-1",
+        userId: "user-2",
+        cancelledAt: null,
+        createdAt: new Date("2026-04-12T00:00:00.000Z"),
+      },
+    });
+
+    const { reservePublicWishlistItemAction } = await import("../../src/app/share/[token]/actions");
+    const formData = new FormData();
+    formData.set("token", "opaque-token");
+    formData.set("itemId", "item-1");
+
+    await expectRedirectCall(
+      () => reservePublicWishlistItemAction(formData),
+      "/share/opaque-token?status=reservation-created",
+    );
+    expect(mocks.createReservation).toHaveBeenCalledWith("user-2", "item-1");
+  });
+
+  it("blocks reserve action for an invalid share or missing item context", async () => {
+    mocks.getCurrentUser.mockResolvedValue({
+      id: "user-2",
+      email: "user@example.com",
+    });
+    mocks.getPublicWishlistViewByShareToken.mockResolvedValue(null);
+
+    const { reservePublicWishlistItemAction } = await import("../../src/app/share/[token]/actions");
+    const formData = new FormData();
+    formData.set("token", "opaque-token");
+    formData.set("itemId", "item-1");
+
+    await expectRedirectCall(
+      () => reservePublicWishlistItemAction(formData),
+      "/share/opaque-token?action=reserve&error=invalid-share",
+    );
+    expect(mocks.createReservation).not.toHaveBeenCalled();
+
+    mocks.getPublicWishlistViewByShareToken.mockResolvedValueOnce({
+      id: "wishlist-1",
+      items: [],
+      shareLink: { id: "share-1", token: "opaque-token" },
+      viewer: { isAuthenticated: true, isOwner: false },
+    });
+
+    await expectRedirectCall(
+      () => reservePublicWishlistItemAction(formData),
+      "/share/opaque-token?action=reserve&error=invalid-share",
+    );
+    expect(mocks.createReservation).not.toHaveBeenCalled();
+  });
+
+  it("blocks reserve action for owner and already-reserved results", async () => {
+    mocks.getCurrentUser.mockResolvedValue({
+      id: "user-2",
+      email: "user@example.com",
+    });
+    mocks.getPublicWishlistViewByShareToken.mockResolvedValue({
+      id: "wishlist-1",
+      items: [
+        {
+          id: "item-1",
+          wishlistId: "wishlist-1",
+          title: "Наушники",
+          url: null,
+          note: null,
+          price: null,
+          createdAt: new Date("2026-04-11T00:00:00.000Z"),
+          updatedAt: new Date("2026-04-11T00:00:00.000Z"),
+          reservation: { status: "available" },
+        },
+      ],
+      shareLink: { id: "share-1", token: "opaque-token" },
+      viewer: { isAuthenticated: true, isOwner: false },
+    });
+
+    const { reservePublicWishlistItemAction } = await import("../../src/app/share/[token]/actions");
+
+    const ownerFormData = new FormData();
+    ownerFormData.set("token", "opaque-token");
+    ownerFormData.set("itemId", "item-1");
+    mocks.createReservation.mockResolvedValueOnce({ status: "error", code: "own-item" });
+
+    await expectRedirectCall(
+      () => reservePublicWishlistItemAction(ownerFormData),
+      "/share/opaque-token?action=reserve&error=own-item",
+    );
+
+    const reservedFormData = new FormData();
+    reservedFormData.set("token", "opaque-token");
+    reservedFormData.set("itemId", "item-1");
+    mocks.createReservation.mockResolvedValueOnce({ status: "error", code: "already-reserved" });
+
+    await expectRedirectCall(
+      () => reservePublicWishlistItemAction(reservedFormData),
+      "/share/opaque-token?action=reserve&error=already-reserved",
+    );
   });
 });


### PR DESCRIPTION
Closes #68 

Expand Milestone 5 coverage so the implemented reservation behavior is protected before moving on to Delivery and Ops. Keep the suite fast and maintainable by strengthening focused unit and route-level tests instead of adding heavier browser infrastructure for the same milestone scope.

## What changed

* expanded reservation lifecycle coverage for:

  * active lookup by item
  * canceled reservations no longer counting as active
  * availability and eligibility rules
  * reservation creation success and failure cases
  * cancellation success and ownership/error cases
* expanded public reservation-aware loading coverage for:

  * valid token with available items
  * valid token with reserved items
  * invalid, inactive, and revoked token cases
* expanded `/share/[token]` coverage for:

  * guest login CTA without reserve controls
  * authenticated non-owner reserve controls
  * owner hidden reserve controls
  * reserved-item rendering
  * success and error feedback
  * reserve action redirects and guard behavior
* expanded owner dashboard coverage for privacy-safe reserved-status rendering on `/app`
* expanded `/app/reservations` coverage for:

  * current user active reservations list
  * empty state
  * cancel success and error feedback
  * cancel action redirect behavior
* added minimal test hooks by exporting the public reserve and cancel server actions for direct testing

## How to verify

* inspect the updated reservation-related test files
* confirm lifecycle rules are covered at helper level
* confirm public share page reserve scenarios are covered at route level
* confirm owner dashboard reserved-status rendering is covered without identity leakage
* confirm `/app/reservations` loading and cancel states are covered
* run the full milestone 5 test command set and confirm all checks pass

## Tests

* `npm run typecheck`
* `npx vitest run tests/unit/reservation-lifecycle.test.ts tests/unit/share-public-wishlist.test.ts tests/unit/share-page.test.ts tests/unit/wishlist-app-bootstrap.test.ts tests/unit/reservation-current-user.test.ts tests/unit/reservations-page.test.ts tests/unit/auth-route-guards.test.ts tests/unit/reservation-owner-wishlist.test.ts`
* `npm run build`

## Documentation

* no additional product or process documentation changes required for this PR
