### PR TITLE
build(compose): add production stack foundation

### DIFF
--- a/.env.compose.example
+++ b/.env.compose.example
@@ -1,0 +1,12 @@
+# Production-oriented Compose env template.
+# Copy to .env.compose.local for local or VPS-level stack values.
+
+APP_IMAGE=wshka-app:local
+
+POSTGRES_DB=wshka
+POSTGRES_USER=wshka
+POSTGRES_PASSWORD=change-me
+
+DATABASE_SSL=false
+
+CADDY_HTTP_PORT=80

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ test-results/
 .env
 .env.local
 .env.docker.local
+.env.compose.local
 .env.development.local
 .env.test.local
 .env.production.local

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,73 @@
+services:
+  postgres:
+    image: postgres:16-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_INITDB_ARGS: --auth-host=scram-sha-256 --auth-local=scram-sha-256
+      POSTGRES_DB: ${POSTGRES_DB}
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER -d $$POSTGRES_DB"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    networks:
+      - stack
+
+  app:
+    image: ${APP_IMAGE:-wshka-app:local}
+    build:
+      context: .
+    restart: unless-stopped
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      DATABASE_URL: postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}
+      DATABASE_SSL: ${DATABASE_SSL:-false}
+      HOSTNAME: 0.0.0.0
+      PORT: 3000
+    expose:
+      - "3000"
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:3000/healthz || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 15s
+    networks:
+      - stack
+
+  caddy:
+    image: caddy:2-alpine
+    restart: unless-stopped
+    depends_on:
+      app:
+        condition: service_healthy
+    ports:
+      - "${CADDY_HTTP_PORT:-80}:80"
+    volumes:
+      - ./ops/caddy/Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy_data:/data
+      - caddy_config:/config
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1/healthz || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+    networks:
+      - stack
+
+volumes:
+  postgres_data:
+  caddy_data:
+  caddy_config:
+
+networks:
+  stack:
+    driver: bridge

--- a/docs/runtime-environment.md
+++ b/docs/runtime-environment.md
@@ -110,6 +110,32 @@
   - `docker build -t wshka-app .`
   - `docker run -p 3000:3000 --env-file .env.docker.local wshka-app`
 
+## Compose Stack Foundation
+- `compose.yaml` is the production-oriented stack foundation for one VPS.
+- The stack shape is:
+  - `caddy` as the public HTTP entrypoint
+  - `app` as the internal Next.js runtime
+  - `postgres` as the internal persistent database
+- `caddy` publishes port `80`.
+- Port `443` remains reserved for the future HTTPS-focused `M6-I4` change and is not published by this foundation yet.
+- `app` is not published externally and is reachable only on the internal Compose network.
+- `postgres` is not published externally and is reachable only on the internal Compose network.
+- Persistent volumes are expected for:
+  - PostgreSQL data
+  - Caddy data
+  - Caddy config state
+- Compose-level values should live in a gitignored `.env.compose.local` file based on `.env.compose.example`.
+- The app runtime env inside Compose still follows the `M6-I1` contract:
+  - `DATABASE_URL`
+  - `DATABASE_SSL`
+- Compose local validation commands:
+  - `docker compose --env-file .env.compose.local config`
+  - `docker compose --env-file .env.compose.local up -d`
+- Compose smoke-check commands:
+  - `docker compose --env-file .env.compose.local ps`
+  - `curl http://localhost/healthz`
+- `M6-I4` is expected to replace the placeholder HTTP-only Caddy foundation with domain-aware production proxy and HTTPS behavior.
+
 ## Rollout And Rollback Assumptions
 - Delivery remains single-environment and single-VPS.
 - A rollout is expected to update the running app version, then verify `/healthz`.

--- a/ops/caddy/Caddyfile
+++ b/ops/caddy/Caddyfile
@@ -1,0 +1,10 @@
+{
+	auto_https off
+	servers :80 {
+		protocols h1
+	}
+}
+
+:80 {
+	reverse_proxy app:3000
+}


### PR DESCRIPTION
Closes #79 

Introduce a minimal production-oriented Docker Compose stack foundation for a one-VPS deployment model. This establishes the orchestration layer for `app`, `postgres`, and `caddy`, aligned with the runtime env contract (M6-I1) and container image model (M6-I2).

## What changed

* added production-oriented `compose.yaml` with three services:
  * `postgres` (persistent database)
  * `app` (Next.js standalone runtime from M6-I2 image)
  * `caddy` (HTTP reverse proxy entrypoint)
* defined service wiring:
  * `app` connects to `postgres` via internal network
  * `caddy` proxies traffic to `app:3000`
* configured persistence:
  * `postgres_data` volume
  * `caddy_data` and `caddy_config` volumes
* defined healthchecks:
  * `postgres` via `pg_isready`
  * `app` via `/healthz`
  * `caddy` via `/healthz` through proxy
* restricted external exposure:
  * only `caddy` publishes a port (`${CADDY_HTTP_PORT:-80}:80`)
  * `app` and `postgres` are internal-only
* added `.env.compose.example`:
  * documents required compose-level variables
  * separates secrets from repository via `.env.compose.local`
* added placeholder `ops/caddy/Caddyfile`:
  * HTTP-only reverse proxy to `app`
  * no HTTPS/domain setup yet (reserved for M6-I4)
* updated `.gitignore` for local env files
* updated `docs/runtime-environment.md` with compose stack assumptions

## How to verify

* prepare local env:
  * `cp .env.compose.example .env.compose.local`
  * optionally set `CADDY_HTTP_PORT=8080`
* build app image:
  * `docker build -t wshka-app:local .`
* validate compose config:
  * `docker compose --env-file .env.compose.local config`
* start stack:
  * `docker compose --env-file .env.compose.local up -d`
* check services:
  * `docker compose --env-file .env.compose.local ps`
* verify entrypoint:
  * `curl http://localhost:8080/healthz`
* inspect logs if needed:
  * `docker compose --env-file .env.compose.local logs --no-color --tail=50`
* stop and clean:
  * `docker compose --env-file .env.compose.local down -v`

## Tests

* no additional infra tests introduced (compose foundation only)
* manually verified:
  * `docker compose config`
  * full stack startup (`postgres`, `app`, `caddy`)
  * internal service connectivity
  * `/healthz` reachable through `caddy`

## Documentation

* updated `docs/runtime-environment.md`:
  * documented compose stack structure and assumptions
  * clarified env separation (compose vs runtime)
* added `.env.compose.example` as source of truth for compose-level variables
* no deploy automation or HTTPS/domain configuration introduced (deferred to next milestones)