### PR TITLE
ci(actions): add GHCR image publish workflow

### DIFF
--- a/.github/workflows/image-publish.yml
+++ b/.github/workflows/image-publish.yml
@@ -1,0 +1,55 @@
+name: M6 Image Publish
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - "v*.*.*"
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  GHCR_IMAGE: ${{ vars.GHCR_IMAGE || format('ghcr.io/{0}/wshka-app', github.repository_owner) }}
+
+jobs:
+  docker-publish:
+    name: docker-publish
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.GHCR_IMAGE }}
+          tags: |
+            type=sha,format=long,prefix=sha-
+            type=raw,value=main,enable={{is_default_branch}}
+            type=ref,event=tag
+            type=semver,pattern={{version}},value=${{ github.ref_name }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ github.ref_name }}
+            type=semver,pattern={{major}},value=${{ github.ref_name }}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Create a wishlist, share it by link, and let another person reserve an item.
 ## Project Docs
 - Product and delivery plan: `master-plan.md`
 - Runtime env and deploy foundation: `docs/runtime-environment.md`
+- GitHub Actions build and image publish: `.github/workflows/`
 - Agent guidance: `AGENTS.md`
 
 ## License

--- a/docs/runtime-environment.md
+++ b/docs/runtime-environment.md
@@ -75,6 +75,27 @@
 | `PRODUCTION_SSH_KEY` | yes | yes | GitHub environment secret | SSH private key for deploy workflow |
 | `GHCR_IMAGE` | yes | no | workflow env or repository variable | Fully qualified image name to publish and deploy |
 
+## GitHub Actions Publish Flow
+- PR build validation is handled by `.github/workflows/baseline-pr-validation.yml`.
+- GHCR image publish is handled by `.github/workflows/image-publish.yml`.
+- The publish workflow uses the existing production `Dockerfile` from `M6-I2`.
+- Publish events are:
+  - push to `main`
+  - push of SemVer tags matching `v*.*.*`
+- Expected image tags:
+  - `sha-<full-commit-sha>` for every publish run
+  - `main` for default branch publishes
+  - `vX.Y.Z`, `X.Y`, and `X` for SemVer tag publishes
+  - `latest` for SemVer tag publishes only
+- Expected GitHub permissions:
+  - `contents: read`
+  - `packages: write`
+- Expected GitHub configuration:
+  - `GHCR_IMAGE` as a repository variable or environment variable
+- If `GHCR_IMAGE` is not set, the workflow falls back to `ghcr.io/<owner>/wshka-app`.
+- No extra registry secret is expected for GHCR publish; the workflow uses `secrets.GITHUB_TOKEN`.
+- `M6-I6` should consume one of the published immutable tags for deploy and rollback decisions rather than rebuilding on the server.
+
 ## One-VPS Production Target
 - One Ubuntu LTS VPS.
 - One production environment only.


### PR DESCRIPTION
Closes #81 

Introduce a minimal GitHub Actions pipeline for production image build, tagging, and publish to GHCR. This establishes a reproducible image distribution layer for the one-VPS deployment model and prepares the foundation for the deploy workflow in M6-I6.

## What changed

* added `.github/workflows/image-publish.yml`:
  * builds production image using existing Dockerfile (M6-I2)
  * sets up Docker Buildx
  * authenticates to GHCR using `GITHUB_TOKEN`
  * generates image metadata and tags via `docker/metadata-action`
  * builds and pushes image via `docker/build-push-action`
* defined publish triggers:
  * on `push` to `main`
  * on SemVer tag `v*.*.*`
* implemented tagging strategy:
  * for `main`:
    * `sha-<commit>`
    * `main`
  * for release tags:
    * `sha-<commit>`
    * `vX.Y.Z`
    * `X.Y`
    * `X`
    * `latest` (release-only)
* ensured fallback image name:
  * uses `GHCR_IMAGE` if provided
  * otherwise defaults to `ghcr.io/<owner>/wshka-app`
* reused existing PR validation workflow:
  * no duplication of build/test checks

## How to verify

* inspect workflow:
  * `.github/workflows/image-publish.yml`
* confirm triggers:
  * push to `main`
  * push tag `v*.*.*`
* verify tagging logic:
  * check `docker/metadata-action` configuration
* validate YAML:
  * run local lint or syntax check
* (on GitHub)
  * push a test branch to `main` → verify image is published with `main` and `sha-*`
  * push a tag `vX.Y.Z` → verify SemVer tags and `latest` are published

Notes:
* actual GHCR publish requires repository permissions and cannot be fully verified locally
* workflow relies on built-in `GITHUB_TOKEN` for registry authentication

## Tests

* no additional runtime or infra tests introduced (CI pipeline foundation only)
* validated:
  * YAML syntax sanity
  * correct reuse of existing Docker build path
  * correct event and tag configuration

## Documentation

* updated `docs/runtime-environment.md`:
  * documented image publish flow and tagging strategy
  * clarified separation between build/publish (M6-I5) and deploy (M6-I6)
* updated `README.md` with high-level CI/CD overview
* no deploy automation introduced (deferred to next milestone)