### PR TITLE
ci(deploy): add VPS rollout health workflow

### DIFF
--- a/.env.compose.production.example
+++ b/.env.compose.production.example
@@ -1,0 +1,14 @@
+# VPS runtime env file.
+# Store the real file on the server as .env.compose.production and keep it out of git.
+# The deploy workflow injects APP_IMAGE dynamically and does not expect it here.
+# POSTGRES_* values are also used to build the production DATABASE_URL for migrations.
+
+CADDY_DOMAIN=wshka.ru
+CADDY_HTTP_PORT=80
+CADDY_HTTPS_PORT=443
+
+POSTGRES_DB=wshka
+POSTGRES_USER=wshka
+POSTGRES_PASSWORD=change-me
+
+DATABASE_SSL=false

--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -1,0 +1,90 @@
+name: M6 Production Deploy
+
+on:
+  release:
+    types:
+      - published
+
+permissions:
+  contents: read
+
+concurrency:
+  group: production-deploy
+  cancel-in-progress: false
+
+env:
+  GHCR_IMAGE: ${{ vars.GHCR_IMAGE || format('ghcr.io/{0}/wshka-app', github.repository_owner) }}
+  GHCR_USERNAME: ${{ vars.GHCR_USERNAME || github.repository_owner }}
+  IMAGE_TAG: ${{ github.event.release.tag_name }}
+  PRODUCTION_APP_DIR: ${{ vars.PRODUCTION_APP_DIR || '/opt/wshka' }}
+  PRODUCTION_HEALTHCHECK_URL: ${{ vars.PRODUCTION_HEALTHCHECK_URL || 'https://wshka.ru/healthz' }}
+  PRODUCTION_HOST: ${{ vars.PRODUCTION_HOST }}
+  PRODUCTION_SSH_PORT: ${{ vars.PRODUCTION_SSH_PORT || '22' }}
+  PRODUCTION_SSH_USER: ${{ vars.PRODUCTION_SSH_USER }}
+
+jobs:
+  deploy:
+    name: deploy
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Configure SSH access
+        shell: bash
+        env:
+          PRODUCTION_SSH_KEY: ${{ secrets.PRODUCTION_SSH_KEY }}
+        run: |
+          set -euo pipefail
+          install -d -m 700 ~/.ssh
+          printf '%s\n' "$PRODUCTION_SSH_KEY" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          ssh-keyscan -p "$PRODUCTION_SSH_PORT" "$PRODUCTION_HOST" >> ~/.ssh/known_hosts
+
+      - name: Prepare remote deploy directory
+        shell: bash
+        run: |
+          set -euo pipefail
+          ssh -p "$PRODUCTION_SSH_PORT" "$PRODUCTION_SSH_USER@$PRODUCTION_HOST" \
+            "mkdir -p '$PRODUCTION_APP_DIR/ops/caddy' '$PRODUCTION_APP_DIR/ops/deploy'"
+
+      - name: Upload deploy artifacts
+        shell: bash
+        run: |
+          set -euo pipefail
+          scp -P "$PRODUCTION_SSH_PORT" compose.yaml \
+            "$PRODUCTION_SSH_USER@$PRODUCTION_HOST:$PRODUCTION_APP_DIR/compose.yaml"
+          scp -P "$PRODUCTION_SSH_PORT" ops/caddy/Caddyfile \
+            "$PRODUCTION_SSH_USER@$PRODUCTION_HOST:$PRODUCTION_APP_DIR/ops/caddy/Caddyfile"
+          scp -P "$PRODUCTION_SSH_PORT" ops/deploy/remote-deploy.sh \
+            "$PRODUCTION_SSH_USER@$PRODUCTION_HOST:$PRODUCTION_APP_DIR/ops/deploy/remote-deploy.sh"
+
+      - name: Upload deploy metadata
+        shell: bash
+        env:
+          GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
+        run: |
+          set -euo pipefail
+          {
+            printf 'APP_IMAGE=%q\n' "$GHCR_IMAGE:$IMAGE_TAG"
+            printf 'GHCR_USERNAME=%q\n' "$GHCR_USERNAME"
+            printf 'GHCR_TOKEN=%q\n' "$GHCR_TOKEN"
+          } > "$RUNNER_TEMP/.deploy.env"
+
+          scp -P "$PRODUCTION_SSH_PORT" "$RUNNER_TEMP/.deploy.env" \
+            "$PRODUCTION_SSH_USER@$PRODUCTION_HOST:$PRODUCTION_APP_DIR/.deploy.env"
+
+      - name: Roll out production stack
+        shell: bash
+        run: |
+          set -euo pipefail
+          ssh -p "$PRODUCTION_SSH_PORT" "$PRODUCTION_SSH_USER@$PRODUCTION_HOST" \
+            "cd '$PRODUCTION_APP_DIR' && chmod +x ops/deploy/remote-deploy.sh && ./ops/deploy/remote-deploy.sh"
+
+      - name: Verify production health
+        shell: bash
+        run: |
+          set -euo pipefail
+          curl --fail --silent --show-error --location \
+            --retry 12 --retry-delay 5 --retry-all-errors \
+            "$PRODUCTION_HEALTHCHECK_URL"

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ test-results/
 .env.local
 .env.docker.local
 .env.compose.local
+.env.compose.production
 .env.development.local
 .env.test.local
 .env.production.local

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,8 +22,11 @@ RUN apk add --no-cache libc6-compat \
 ENV NODE_ENV=production
 ENV HOSTNAME=0.0.0.0
 ENV PORT=3000
+COPY --from=deps /app/node_modules ./node_modules
 COPY --from=builder /app/.next/standalone ./
 COPY --from=builder /app/.next/static ./.next/static
+COPY drizzle ./drizzle
+COPY ops/deploy/run-migrations.mjs ./ops/deploy/run-migrations.mjs
 USER nextjs
 EXPOSE 3000
 CMD ["node", "server.js"]

--- a/docs/runtime-environment.md
+++ b/docs/runtime-environment.md
@@ -73,7 +73,11 @@
 | `PRODUCTION_SSH_USER` | yes | no | GitHub environment variable or workflow env | SSH user for deploy access |
 | `PRODUCTION_SSH_PORT` | no | no | GitHub environment variable or workflow env | SSH port, default `22` |
 | `PRODUCTION_SSH_KEY` | yes | yes | GitHub environment secret | SSH private key for deploy workflow |
+| `PRODUCTION_APP_DIR` | no | no | GitHub environment variable or workflow env | Target application directory on the VPS; default `/opt/wshka` |
+| `PRODUCTION_HEALTHCHECK_URL` | no | no | GitHub environment variable or workflow env | Public deploy verification URL; default `https://wshka.ru/healthz` |
 | `GHCR_IMAGE` | yes | no | workflow env or repository variable | Fully qualified image name to publish and deploy |
+| `GHCR_USERNAME` | no | no | GitHub environment variable or workflow env | GHCR username for remote image pull; defaults to repository owner |
+| `GHCR_TOKEN` | yes | yes | GitHub environment secret | GHCR read token for pulling the published image on the VPS |
 
 ## GitHub Actions Publish Flow
 - PR build validation is handled by `.github/workflows/baseline-pr-validation.yml`.
@@ -95,6 +99,35 @@
 - If `GHCR_IMAGE` is not set, the workflow falls back to `ghcr.io/<owner>/wshka-app`.
 - No extra registry secret is expected for GHCR publish; the workflow uses `secrets.GITHUB_TOKEN`.
 - `M6-I6` should consume one of the published immutable tags for deploy and rollback decisions rather than rebuilding on the server.
+
+## GitHub Actions Deploy Flow
+- Production deploy is handled by `.github/workflows/production-deploy.yml`.
+- The deploy workflow triggers on `release.published` only.
+- The deployed image tag is the GitHub Release tag name.
+- The deploy workflow uses the already-published GHCR image from `M6-I5` and does not rebuild on the VPS.
+- The workflow uploads these tracked deployment artifacts to the VPS application directory:
+  - `compose.yaml`
+  - `ops/caddy/Caddyfile`
+  - `ops/deploy/remote-deploy.sh`
+- The VPS must already contain a gitignored runtime file at `<PRODUCTION_APP_DIR>/.env.compose.production` based on `.env.compose.production.example`.
+- Remote deploy steps are:
+  - authenticate to GHCR with an ephemeral Docker config
+  - validate `docker compose` config using `.env.compose.production`
+  - start `postgres` and wait for it to become healthy
+  - run the production migration step before the updated app is started
+  - pull the target app image tag
+  - run `docker compose up -d --no-build --force-recreate app caddy`
+  - print `docker compose ps`
+- Post-deploy verification is an external health check against `https://wshka.ru/healthz` by default.
+- A failed public health check fails the workflow.
+- A failed migration step fails the deploy before the updated app is rolled out.
+- The migration step uses the same production database wiring shape as app runtime:
+  - `postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}`
+  - `DATABASE_SSL`
+- The published app image includes a dedicated migration runner at `node /app/ops/deploy/run-migrations.mjs`.
+- Rollback expectation remains minimal and explicit:
+  - redeploy the previous known-good immutable image tag through the same compose path
+  - do not rebuild on the VPS during rollback
 
 ## One-VPS Production Target
 - One Ubuntu LTS VPS.
@@ -145,6 +178,7 @@
   - Caddy data
   - Caddy config state
 - Compose-level values should live in a gitignored `.env.compose.local` file based on `.env.compose.example`.
+- VPS runtime values should live in a gitignored `.env.compose.production` file based on `.env.compose.production.example`.
 - The app runtime env inside Compose still follows the `M6-I1` contract:
   - `DATABASE_URL`
   - `DATABASE_SSL`

--- a/ops/deploy/remote-deploy.sh
+++ b/ops/deploy/remote-deploy.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+: "${PWD:?working directory is required}"
+
+if [[ ! -f .env.compose.production ]]; then
+  echo "Missing .env.compose.production in $(pwd)"
+  exit 1
+fi
+
+if [[ ! -f .deploy.env ]]; then
+  echo "Missing .deploy.env in $(pwd)"
+  exit 1
+fi
+
+set -a
+. ./.deploy.env
+set +a
+
+: "${APP_IMAGE:?APP_IMAGE is required}"
+: "${GHCR_USERNAME:?GHCR_USERNAME is required}"
+: "${GHCR_TOKEN:?GHCR_TOKEN is required}"
+
+wait_for_service_health() {
+  local service="$1"
+  local container_id=""
+  local status=""
+
+  for _ in $(seq 1 30); do
+    container_id="$(docker compose --env-file .env.compose.production ps -q "$service")"
+
+    if [[ -n "$container_id" ]]; then
+      status="$(docker inspect -f '{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}' "$container_id" 2>/dev/null || true)"
+
+      if [[ "$status" == "healthy" ]]; then
+        return 0
+      fi
+    fi
+
+    sleep 2
+  done
+
+  echo "Timed out waiting for $service to become healthy"
+  return 1
+}
+
+cleanup() {
+  rm -f ./.deploy.env
+
+  if [[ -n "${DOCKER_CONFIG:-}" && -d "${DOCKER_CONFIG}" ]]; then
+    rm -rf "${DOCKER_CONFIG}"
+  fi
+}
+
+trap cleanup EXIT
+
+DOCKER_CONFIG="$(mktemp -d)"
+export DOCKER_CONFIG
+
+printf '%s' "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_USERNAME" --password-stdin
+
+export APP_IMAGE
+
+docker compose --env-file .env.compose.production config >/dev/null
+docker compose --env-file .env.compose.production up -d postgres
+wait_for_service_health postgres
+docker compose --env-file .env.compose.production pull app
+docker compose --env-file .env.compose.production run --rm --no-deps app \
+  node /app/ops/deploy/run-migrations.mjs
+docker compose --env-file .env.compose.production up -d --no-build --force-recreate app caddy
+docker compose --env-file .env.compose.production ps

--- a/ops/deploy/run-migrations.mjs
+++ b/ops/deploy/run-migrations.mjs
@@ -1,0 +1,32 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { drizzle } from "drizzle-orm/node-postgres";
+import { migrate } from "drizzle-orm/node-postgres/migrator";
+import { Pool } from "pg";
+
+const databaseUrl = process.env.DATABASE_URL;
+
+if (!databaseUrl) {
+  throw new Error("DATABASE_URL is required to run migrations.");
+}
+
+const databaseSsl = ["true", "1", "yes"].includes(
+  (process.env.DATABASE_SSL ?? "").trim().toLowerCase(),
+);
+
+const scriptDirectory = path.dirname(fileURLToPath(import.meta.url));
+const migrationsFolder = path.resolve(scriptDirectory, "../../drizzle");
+
+const pool = new Pool({
+  connectionString: databaseUrl,
+  ssl: databaseSsl ? { rejectUnauthorized: false } : undefined,
+});
+
+try {
+  const db = drizzle(pool);
+
+  await migrate(db, { migrationsFolder });
+} finally {
+  await pool.end();
+}


### PR DESCRIPTION
Closes #82 

Introduce a minimal production deploy workflow for a one-VPS environment with an integrated database migration step. The workflow performs SSH-based rollout using a pre-built GHCR image, applies schema migrations, and verifies deployment success via a public `/healthz` endpoint.

## What changed

* added `.github/workflows/production-deploy.yml`:
  * triggers on `release.published`
  * connects to VPS via SSH
  * uploads deploy artifacts:
    * `compose.yaml`
    * `ops/caddy/Caddyfile`
    * `ops/deploy/remote-deploy.sh`
  * passes deploy-time variables via temporary `.deploy.env`
  * executes remote rollout script
  * performs post-deploy health check
* added `ops/deploy/remote-deploy.sh`:
  * validates compose config
  * ensures `postgres` is running and healthy
  * pulls target image from GHCR
  * runs database migrations before app rollout
  * updates services:
    * `app`
    * `caddy`
  * prints service status
  * removes temporary credentials after deploy
* added `ops/deploy/run-migrations.mjs`:
  * runs Drizzle migrations using production database connection
  * uses same runtime DB contract as application
  * safe to run multiple times (idempotent)
* updated `Dockerfile` to include migration runner in runtime image
* added `.env.compose.production.example`:
  * documents required production runtime variables
  * clarifies DB variables are used for both app and migration step
* updated `.gitignore` for deploy artifacts
* updated `docs/runtime-environment.md`:
  * documented deploy workflow and migration step
  * clarified deploy sequence and failure conditions
  * documented rollback expectations

## How to verify

* ensure repository secrets and variables are configured:
  * `PRODUCTION_HOST`
  * `PRODUCTION_SSH_USER`
  * `PRODUCTION_SSH_KEY`
  * optional: `PRODUCTION_SSH_PORT`, `PRODUCTION_APP_DIR`, `PRODUCTION_HEALTHCHECK_URL`
  * `GHCR_IMAGE`, `GHCR_TOKEN`
* ensure VPS is prepared:
  * Docker and Docker Compose v2 installed
  * `<APP_DIR>/.env.compose.production` exists
  * DNS for `wshka.ru` points to VPS
  * ports 80/443 are accessible
* create a release with tag `vX.Y.Z`
* verify on GitHub:
  * workflow runs successfully
* verify deployment:
  * `https://wshka.ru/healthz` returns success
* verify migrations:
  * schema is up to date in production database
* inspect logs if needed:
  * workflow logs on GitHub
  * `docker compose logs` on VPS

Notes:
* deploy uses already published GHCR image
* no build occurs on VPS
* migrations are applied before app rollout
* migration failure stops deploy
* local execution of this workflow is not possible

## Tests

* no additional infra tests introduced (deploy workflow only)
* validated:
  * workflow YAML syntax
  * shell script syntax
  * migration runner syntax and execution
  * variable and secret references consistency

## Documentation

* updated `docs/runtime-environment.md`:
  * documented deploy workflow and required inputs
  * documented migration step and execution order
  * documented `/healthz` verification flow
  * documented rollback via previous immutable image tag
* added `.env.compose.production.example` as production env contract reference
* no additional infra automation introduced beyond deploy workflow