### PR TITLE
test(e2e): add owner journey coverage

### DIFF
--- a/src/app/app/page.tsx
+++ b/src/app/app/page.tsx
@@ -79,13 +79,19 @@ export default async function AppPage(props: AppPageProps) {
               <dl className="grid gap-3 sm:grid-cols-2">
                 <div>
                   <dt className="ui-note">ID</dt>
-                  <dd className="mt-1 break-all font-medium text-[color:var(--color-text-strong)]">
+                  <dd
+                    data-testid="wishlist-id"
+                    className="mt-1 break-all font-medium text-[color:var(--color-text-strong)]"
+                  >
                     {wishlist.id}
                   </dd>
                 </div>
                 <div>
                   <dt className="ui-note">{messages.dashboard.itemCountLabel}</dt>
-                  <dd className="mt-1 font-medium text-[color:var(--color-text-strong)]">
+                  <dd
+                    data-testid="wishlist-item-count"
+                    className="mt-1 font-medium text-[color:var(--color-text-strong)]"
+                  >
                     {wishlist.items.length}
                   </dd>
                 </div>
@@ -119,6 +125,7 @@ export default async function AppPage(props: AppPageProps) {
                   </label>
                   <input
                     id="share-link-url"
+                    data-testid="share-link-url"
                     value={currentShareUrl}
                     readOnly
                     className="ui-input"
@@ -160,7 +167,11 @@ export default async function AppPage(props: AppPageProps) {
                 {messages.dashboard.formTitle}
               </h2>
             </div>
-            <form action={createItemAction} className="ui-form max-w-none">
+            <form
+              action={createItemAction}
+              className="ui-form max-w-none"
+              data-testid="wishlist-create-form"
+            >
               <div className="ui-field">
                 <label className="ui-label" htmlFor="title">
                   {messages.dashboard.fields.title}
@@ -195,7 +206,7 @@ export default async function AppPage(props: AppPageProps) {
         </section>
 
         {wishlist.items.length === 0 ? (
-          <section className="ui-surface p-6">
+          <section className="ui-surface p-6" data-testid="wishlist-empty-state">
             <h2 className="text-lg font-semibold text-[color:var(--color-text-strong)]">
               {messages.dashboard.emptyTitle}
             </h2>

--- a/tests/e2e/owner-journey.spec.ts
+++ b/tests/e2e/owner-journey.spec.ts
@@ -1,0 +1,179 @@
+import { randomUUID } from "node:crypto";
+import { expect, test, type Page } from "@playwright/test";
+
+type OwnerCredentials = {
+  email: string;
+  password: string;
+};
+
+test("owner can complete the core wishlist journey end to end", async ({ page }) => {
+  const credentials = createOwnerCredentials();
+  const itemRunId = randomUUID().slice(0, 8);
+  const initialItem = {
+    title: `Owner journey item ${itemRunId}`,
+    url: `https://example.com/items/${itemRunId}`,
+    note: `Initial note ${itemRunId}`,
+    price: "1990",
+  };
+  const updatedItem = {
+    title: `Updated owner journey item ${itemRunId}`,
+    url: `https://example.com/items/${itemRunId}/updated`,
+    note: `Updated note ${itemRunId}`,
+    price: "2490.5",
+  };
+
+  await test.step("register a new owner account", async () => {
+    await registerOwner(page, credentials);
+
+    await expect(page).toHaveURL(/\/register\?status=success$/);
+    await expect(page.getByText("Аккаунт создан. Теперь можно перейти к будущему сценарию входа.")).toBeVisible();
+  });
+
+  await test.step("log in and land on the bootstrapped /app state", async () => {
+    await loginOwner(page, credentials);
+
+    await expect(page).toHaveURL(/\/app(?:\?.*)?$/);
+    await expect(page.getByRole("heading", { name: "Мой вишлист" })).toBeVisible();
+    await expect(page.getByTestId("wishlist-id")).toHaveText(/.+/);
+    await expect(page.getByTestId("wishlist-item-count")).toHaveText("0");
+    await expect(page.getByTestId("wishlist-empty-state")).toBeVisible();
+    await expect(page.getByRole("button", { name: "Создать публичную ссылку" })).toBeVisible();
+
+    const sessionCookie = (await page.context().cookies()).find(
+      ({ name }) => name === "wshka_session",
+    );
+
+    expect(sessionCookie?.value).toBeTruthy();
+  });
+
+  await test.step("create and update a wishlist item", async () => {
+    const createForm = page.getByTestId("wishlist-create-form");
+
+    await createForm.getByLabel("Название").fill(initialItem.title);
+    await createForm.getByLabel("Ссылка").fill(initialItem.url);
+    await createForm.getByLabel("Заметка").fill(initialItem.note);
+    await createForm.getByLabel("Цена").fill(initialItem.price);
+    await createForm.getByRole("button", { name: "Добавить в вишлист" }).click();
+
+    await expect(page).toHaveURL(/\/app\?status=item-created$/);
+    await expect(page.getByText("Желание добавлено в текущий вишлист.")).toBeVisible();
+    await expect(page.getByTestId("wishlist-item-count")).toHaveText("1");
+
+    const createdItemCard = getWishlistItemCard(page, initialItem.title);
+
+    await expect(createdItemCard).toContainText(initialItem.url);
+    await expect(createdItemCard).toContainText(initialItem.note);
+    await expect(createdItemCard).toContainText("1990.00");
+    await expect(createdItemCard).toContainText("Статус: доступно");
+
+    const updateForm = createdItemCard.locator("form").filter({
+      has: page.getByRole("button", { name: "Сохранить изменения" }),
+    });
+
+    await updateForm.getByLabel("Название").fill(updatedItem.title);
+    await updateForm.getByLabel("Ссылка").fill(updatedItem.url);
+    await updateForm.getByLabel("Заметка").fill(updatedItem.note);
+    await updateForm.getByLabel("Цена").fill(updatedItem.price);
+    await updateForm.getByRole("button", { name: "Сохранить изменения" }).click();
+
+    await expect(page).toHaveURL(/\/app\?status=item-updated$/);
+    await expect(page.getByText("Желание обновлено.")).toBeVisible();
+    await expect(page.getByRole("heading", { name: initialItem.title, exact: true })).toHaveCount(0);
+
+    const updatedItemCard = getWishlistItemCard(page, updatedItem.title);
+
+    await expect(updatedItemCard).toContainText(updatedItem.url);
+    await expect(updatedItemCard).toContainText(updatedItem.note);
+    await expect(updatedItemCard).toContainText("2490.50");
+  });
+
+  await test.step("create, regenerate, and revoke a share link", async () => {
+    await page.getByRole("button", { name: "Создать публичную ссылку" }).click();
+
+    await expect(page).toHaveURL(/\/app\?status=share-link-created$/);
+    await expect(page.getByText("Публичная ссылка готова.")).toBeVisible();
+    await expect(page.getByTestId("share-link-url")).toHaveValue(/\/share\//);
+
+    const firstShareUrl = await page.getByTestId("share-link-url").inputValue();
+    const sharePreviewPage = await page.context().newPage();
+
+    await sharePreviewPage.goto(firstShareUrl);
+    await expect(sharePreviewPage.getByRole("heading", { name: "Публичный вишлист" })).toBeVisible();
+    await expect(sharePreviewPage.getByText("Это ваш вишлист. Бронировать собственные желания нельзя.")).toBeVisible();
+    await expect(sharePreviewPage.getByRole("heading", { name: updatedItem.title })).toBeVisible();
+
+    await page.getByRole("button", { name: "Создать новую ссылку" }).click();
+
+    await expect(page).toHaveURL(/\/app\?status=share-link-regenerated$/);
+    await expect(page.getByText("Создана новая публичная ссылка.")).toBeVisible();
+
+    const regeneratedShareUrl = await page.getByTestId("share-link-url").inputValue();
+
+    expect(regeneratedShareUrl).not.toBe(firstShareUrl);
+
+    await sharePreviewPage.goto(firstShareUrl);
+    await expect(
+      sharePreviewPage.getByRole("heading", { name: "Публичная ссылка недоступна" }),
+    ).toBeVisible();
+
+    await sharePreviewPage.goto(regeneratedShareUrl);
+    await expect(sharePreviewPage.getByRole("heading", { name: "Публичный вишлист" })).toBeVisible();
+    await expect(sharePreviewPage.getByRole("heading", { name: updatedItem.title })).toBeVisible();
+
+    await page.getByRole("button", { name: "Отключить ссылку" }).click();
+
+    await expect(page).toHaveURL(/\/app\?status=share-link-revoked$/);
+    await expect(page.getByText("Публичная ссылка отключена.")).toBeVisible();
+    await expect(page.getByRole("button", { name: "Создать публичную ссылку" })).toBeVisible();
+
+    await sharePreviewPage.goto(regeneratedShareUrl);
+    await expect(
+      sharePreviewPage.getByRole("heading", { name: "Публичная ссылка недоступна" }),
+    ).toBeVisible();
+
+    await sharePreviewPage.close();
+  });
+
+  await test.step("delete the item and return to the empty state", async () => {
+    const updatedItemCard = getWishlistItemCard(page, updatedItem.title);
+
+    await updatedItemCard.getByRole("button", { name: "Удалить желание" }).click();
+
+    await expect(page).toHaveURL(/\/app\?status=item-deleted$/);
+    await expect(page.getByText("Желание удалено из текущего вишлиста.")).toBeVisible();
+    await expect(page.getByTestId("wishlist-item-count")).toHaveText("0");
+    await expect(page.getByTestId("wishlist-empty-state")).toBeVisible();
+    await expect(page.getByRole("heading", { name: updatedItem.title, exact: true })).toHaveCount(0);
+  });
+});
+
+function createOwnerCredentials(): OwnerCredentials {
+  const runId = randomUUID().slice(0, 12);
+
+  return {
+    email: `owner-journey-${runId}@example.com`,
+    password: `OwnerJourney!${runId}`,
+  };
+}
+
+async function registerOwner(page: Page, credentials: OwnerCredentials) {
+  await page.goto("/register");
+  await expect(page.getByRole("heading", { name: "Регистрация" })).toBeVisible();
+  await page.getByLabel("Email").fill(credentials.email);
+  await page.getByLabel("Пароль").fill(credentials.password);
+  await page.getByRole("button", { name: "Создать аккаунт" }).click();
+}
+
+async function loginOwner(page: Page, credentials: OwnerCredentials) {
+  await page.goto("/login");
+  await expect(page.getByRole("heading", { name: "Вход" })).toBeVisible();
+  await page.getByLabel("Email").fill(credentials.email);
+  await page.getByLabel("Пароль").fill(credentials.password);
+  await page.getByRole("button", { name: "Войти" }).click();
+}
+
+function getWishlistItemCard(page: Page, title: string) {
+  return page.locator("li").filter({
+    has: page.getByRole("heading", { name: title, exact: true }),
+  });
+}


### PR DESCRIPTION
Closes #94 

Introduce minimal end-to-end coverage for the core owner journey using Playwright.

## What changed

* added `tests/e2e/owner-journey.spec.ts`:

  * one end-to-end scenario covering:

    * registration → login → `/app`
    * wishlist bootstrap and empty state
    * item CRUD (create, update, delete)
    * share link lifecycle (create, open, regenerate, revoke)
* added minimal test helpers inside the spec:

  * `createOwnerCredentials()`
  * `registerOwner()`
  * `loginOwner()`
  * `getWishlistItemCard()`
* updated `src/app/app/page.tsx`:

  * added minimal `data-testid` attributes for stable e2e selectors:

    * `wishlist-id`
    * `wishlist-item-count`
    * `wishlist-create-form`
    * `share-link-url`
    * `wishlist-empty-state`

## How to verify

* run typecheck:

```bash
npm run typecheck
```

* run the e2e test:

```bash
npx playwright test tests/e2e/owner-journey.spec.ts
```

* expected result:

  * test passes consistently
  * scenario completes full owner journey without failures

## Tests

* added Playwright e2e coverage for owner journey
* test characteristics:

  * deterministic (unique user and data per run)
  * isolated (no cross-test dependencies)
  * uses stable selectors (`data-testid`)
  * avoids sleeps and fragile DOM assumptions

## Documentation

* no documentation changes required
* test serves as executable specification of the owner journey
