### PR TITLE
test(e2e): add public reservation coverage

### DIFF
--- a/src/app/app/reservations/page.tsx
+++ b/src/app/app/reservations/page.tsx
@@ -38,7 +38,7 @@ export default async function ReservationsPage(props: ReservationsPageProps) {
         </p>
       ) : null}
       {reservations.length === 0 ? (
-        <section className="ui-surface p-6">
+        <section className="ui-surface p-6" data-testid="reservations-empty-state">
           <h2 className="text-lg font-semibold text-[color:var(--color-text-strong)]">
             {messages.reservations.emptyTitle}
           </h2>
@@ -53,7 +53,7 @@ export default async function ReservationsPage(props: ReservationsPageProps) {
           </h2>
           <ul className="space-y-4">
             {reservations.map((reservation) => (
-              <li key={reservation.id} className="ui-surface p-6">
+              <li key={reservation.id} className="ui-surface p-6" data-testid="reservation-card">
                 <div className="space-y-4">
                   <div className="space-y-3">
                     <h3 className="text-base font-semibold text-[color:var(--color-text-strong)]">

--- a/src/app/share/[token]/page.tsx
+++ b/src/app/share/[token]/page.tsx
@@ -54,7 +54,7 @@ export default async function SharePage(props: SharePageProps) {
         <p className="ui-message ui-message-error">{getShareActionErrorMessage(action, errorCode)}</p>
       ) : null}
       {!publicWishlist.viewer.isAuthenticated ? (
-        <div className="ui-surface p-4">
+        <div className="ui-surface p-4" data-testid="share-guest-guard">
           <p className="text-sm text-[color:var(--color-text-base)]">{messages.share.guestHint}</p>
           <div className="mt-3">
             <Link href="/login" className="ui-button inline-flex">
@@ -81,7 +81,7 @@ export default async function SharePage(props: SharePageProps) {
           </h2>
           <ul className="space-y-4">
             {publicWishlist.items.map((item) => (
-              <li key={item.id} className="ui-surface p-6">
+              <li key={item.id} className="ui-surface p-6" data-testid="share-item-card">
                 <div className="space-y-3">
                   <h3 className="text-base font-semibold text-[color:var(--color-text-strong)]">
                     {item.title}

--- a/tests/e2e/public-reservation.spec.ts
+++ b/tests/e2e/public-reservation.spec.ts
@@ -1,0 +1,179 @@
+import { randomUUID } from "node:crypto";
+import { expect, test, type Page } from "@playwright/test";
+
+type Credentials = {
+  email: string;
+  password: string;
+};
+
+test("public wishlist and reserver journey works end to end", async ({ browser }) => {
+  const owner = createCredentials("owner");
+  const reserver = createCredentials("reserver");
+  const runId = randomUUID().slice(0, 8);
+  const item = {
+    title: `Shared item ${runId}`,
+    url: `https://example.com/shared/${runId}`,
+    note: `Shared note ${runId}`,
+    price: "3490",
+  };
+
+  const ownerContext = await browser.newContext();
+  const guestContext = await browser.newContext();
+  const reserverContext = await browser.newContext();
+  const ownerPage = await ownerContext.newPage();
+  const guestPage = await guestContext.newPage();
+  const reserverPage = await reserverContext.newPage();
+
+  try {
+    const shareUrl = await test.step("owner prepares a public wishlist with one item", async () => {
+      await registerUser(ownerPage, owner);
+      await loginUser(ownerPage, owner);
+      await createWishlistItem(ownerPage, item);
+
+      await ownerPage.getByRole("button", { name: "Создать публичную ссылку" }).click();
+
+      await expect(ownerPage).toHaveURL(/\/app\?status=share-link-created$/);
+      await expect(ownerPage.getByTestId("share-link-url")).toHaveValue(/\/share\//);
+
+      return ownerPage.getByTestId("share-link-url").inputValue();
+    });
+
+    await test.step("guest can view the shared wishlist but cannot reserve", async () => {
+      await guestPage.goto(await shareUrl);
+
+      await expect(guestPage.getByRole("heading", { name: "Публичный вишлист" })).toBeVisible();
+      await expect(guestPage.getByTestId("share-guest-guard")).toContainText(
+        "Войдите, чтобы забронировать доступное желание.",
+      );
+
+      const guestItemCard = getShareItemCard(guestPage, item.title);
+
+      await expect(guestItemCard).toContainText(item.url);
+      await expect(guestItemCard).toContainText(item.note);
+      await expect(guestItemCard).toContainText("3490.00");
+      await expect(guestItemCard.getByRole("button", { name: "Забронировать" })).toHaveCount(0);
+      await expect(guestPage.getByText(owner.email)).toHaveCount(0);
+      await expect(guestPage.getByText(reserver.email)).toHaveCount(0);
+    });
+
+    await test.step("authenticated non-owner can reserve the shared item", async () => {
+      await registerUser(reserverPage, reserver);
+      await loginUser(reserverPage, reserver);
+      await reserverPage.goto(await shareUrl);
+
+      const availableItemCard = getShareItemCard(reserverPage, item.title);
+
+      await expect(availableItemCard.getByRole("button", { name: "Забронировать" })).toBeVisible();
+      await availableItemCard.getByRole("button", { name: "Забронировать" }).click();
+
+      await expect(reserverPage).toHaveURL(/\/share\/.*\?status=reservation-created$/);
+      await expect(reserverPage.getByText("Желание забронировано.")).toBeVisible();
+
+      const reservedItemCard = getShareItemCard(reserverPage, item.title);
+
+      await expect(reservedItemCard).toContainText("Уже забронировано");
+      await expect(reservedItemCard.getByRole("button", { name: "Забронировать" })).toHaveCount(0);
+      await expect(reserverPage.getByText(owner.email)).toHaveCount(0);
+      await expect(reserverPage.getByText(reserver.email)).toHaveCount(0);
+    });
+
+    await test.step("other viewers see the reserved state without identity leakage", async () => {
+      await guestPage.goto(await shareUrl);
+
+      const guestReservedItemCard = getShareItemCard(guestPage, item.title);
+
+      await expect(guestReservedItemCard).toContainText("Уже забронировано");
+      await expect(guestReservedItemCard.getByRole("button", { name: "Забронировать" })).toHaveCount(0);
+      await expect(guestPage.getByText(owner.email)).toHaveCount(0);
+      await expect(guestPage.getByText(reserver.email)).toHaveCount(0);
+    });
+
+    await test.step("reserver can cancel the reservation from /app/reservations", async () => {
+      await reserverPage.goto("/app/reservations");
+
+      await expect(reserverPage.getByRole("heading", { name: "Бронирования" })).toBeVisible();
+
+      const reservationCard = getReservationCard(reserverPage, item.title);
+
+      await expect(reservationCard).toContainText(item.url);
+      await expect(reservationCard).toContainText(item.note);
+      await expect(reservationCard).toContainText("3490.00");
+      await reservationCard.getByRole("button", { name: "Отменить бронь" }).click();
+
+      await expect(reserverPage).toHaveURL(/\/app\/reservations\?status=reservation-cancelled$/);
+      await expect(reserverPage.getByText("Бронь отменена.")).toBeVisible();
+      await expect(reserverPage.getByTestId("reservations-empty-state")).toBeVisible();
+      await expect(reserverPage.getByRole("heading", { name: item.title, exact: true })).toHaveCount(0);
+    });
+
+    await test.step("after cancellation the shared item becomes available again", async () => {
+      await reserverPage.goto(await shareUrl);
+
+      const availableAgainItemCard = getShareItemCard(reserverPage, item.title);
+
+      await expect(availableAgainItemCard.getByRole("button", { name: "Забронировать" })).toBeVisible();
+      await expect(availableAgainItemCard.getByText("Уже забронировано")).toHaveCount(0);
+    });
+  } finally {
+    await Promise.all([
+      ownerContext.close(),
+      guestContext.close(),
+      reserverContext.close(),
+    ]);
+  }
+});
+
+function createCredentials(prefix: string): Credentials {
+  const runId = randomUUID().slice(0, 12);
+
+  return {
+    email: `${prefix}-${runId}@example.com`,
+    password: `Password!${runId}`,
+  };
+}
+
+async function registerUser(page: Page, credentials: Credentials) {
+  await page.goto("/register");
+  await expect(page.getByRole("heading", { name: "Регистрация" })).toBeVisible();
+  await page.getByLabel("Email").fill(credentials.email);
+  await page.getByLabel("Пароль").fill(credentials.password);
+  await page.getByRole("button", { name: "Создать аккаунт" }).click();
+  await expect(page).toHaveURL(/\/register\?status=success$/);
+}
+
+async function loginUser(page: Page, credentials: Credentials) {
+  await page.goto("/login");
+  await expect(page.getByRole("heading", { name: "Вход" })).toBeVisible();
+  await page.getByLabel("Email").fill(credentials.email);
+  await page.getByLabel("Пароль").fill(credentials.password);
+  await page.getByRole("button", { name: "Войти" }).click();
+  await expect(page).toHaveURL(/\/app(?:\?.*)?$/);
+}
+
+async function createWishlistItem(
+  page: Page,
+  item: { title: string; url: string; note: string; price: string },
+) {
+  const createForm = page.getByTestId("wishlist-create-form");
+
+  await createForm.getByLabel("Название").fill(item.title);
+  await createForm.getByLabel("Ссылка").fill(item.url);
+  await createForm.getByLabel("Заметка").fill(item.note);
+  await createForm.getByLabel("Цена").fill(item.price);
+  await createForm.getByRole("button", { name: "Добавить в вишлист" }).click();
+
+  await expect(page).toHaveURL(/\/app\?status=item-created$/);
+  await expect(page.getByTestId("wishlist-item-count")).toHaveText("1");
+}
+
+function getShareItemCard(page: Page, title: string) {
+  return page.getByTestId("share-item-card").filter({
+    has: page.getByRole("heading", { name: title, exact: true }),
+  });
+}
+
+function getReservationCard(page: Page, title: string) {
+  return page.getByTestId("reservation-card").filter({
+    has: page.getByRole("heading", { name: title, exact: true }),
+  });
+}


### PR DESCRIPTION
Closes #95 

Introduce minimal end-to-end coverage for the public share and reservation flow using Playwright.

## What changed

* added `tests/e2e/public-reservation.spec.ts`:

  * one end-to-end scenario covering:

    * owner setup (wishlist item + share link)
    * public wishlist access via `/share/[token]`
    * guest behavior (view-only, no reservation)
    * authenticated non-owner reservation flow
    * reserved state in public UI
    * reservation cancel flow via `/app/reservations`
    * post-cancel availability on share page
* updated:

  * `src/app/share/[token]/page.tsx`
  * `src/app/app/reservations/page.tsx`
  * added minimal `data-testid` attributes for stable e2e selectors:

    * `share-guest-guard`
    * `share-item-card`
    * `reservation-card`
    * `reservations-empty-state`
* added minimal test helpers inside the spec:

  * `createCredentials()`
  * `registerUser()`
  * `loginUser()`
  * `createWishlistItem()`
  * `getShareItemCard()`
  * `getReservationCard()`

## How to verify

* run typecheck:

```bash
npm run typecheck
```

* run the e2e test:

```bash
npx playwright test tests/e2e/public-reservation.spec.ts
```

* expected result:

  * test passes consistently
  * scenario completes full public → reservation → cancel → availability flow

## Tests

* added Playwright e2e coverage for public/share/reserver journey
* test characteristics:

  * deterministic (separate users for owner and reserver)
  * isolated (no cross-test dependencies)
  * uses stable selectors (`data-testid`)
  * avoids sleeps and fragile DOM assumptions
* verifies:

  * guest cannot reserve
  * non-owner can reserve
  * reservation state is reflected
  * reservation can be canceled
  * item becomes available again after cancel
  * no reserver identity leakage in public UI

## Documentation

* no documentation changes required
* test serves as executable specification of the public/reservation flow
