### PR TITLE
fix(auth): harden session and route behavior

### DIFF
--- a/master-plan.md
+++ b/master-plan.md
@@ -741,3 +741,6 @@ Recommended planning rule:
 - `v1.4.0`: dark theme
 - `v1.5.0`: email verification and password reset
 - `v1.6.0`: api documentation (swagger / openapi)
+- Add a password repeat on registration
+- Fix UI
+- Reorganize the repository structure

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,7 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
+  allowedDevOrigins: ["127.0.0.1"],
   output: "standalone",
 };
 

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,4 +1,5 @@
 import { redirect } from "next/navigation";
+import { getCurrentUser } from "@/modules/auth/server/current-user";
 import { getTranslations } from "@/modules/i18n";
 import { PageShell } from "@/shared/ui/page-shell";
 
@@ -13,6 +14,12 @@ type LoginPageProps = {
 };
 
 export default async function LoginPage({ searchParams }: LoginPageProps) {
+  const currentUser = await getCurrentUser();
+
+  if (currentUser) {
+    redirect("/app");
+  }
+
   const params = searchParams ? await searchParams : undefined;
   const status = params?.status;
   const errorCode = params?.error;

--- a/src/app/register/page.tsx
+++ b/src/app/register/page.tsx
@@ -1,4 +1,5 @@
 import { redirect } from "next/navigation";
+import { getCurrentUser } from "@/modules/auth/server/current-user";
 import { MIN_PASSWORD_LENGTH } from "@/modules/auth/server/register-input";
 import { getTranslations } from "@/modules/i18n";
 import { PageShell } from "@/shared/ui/page-shell";
@@ -14,6 +15,12 @@ type RegisterPageProps = {
 };
 
 export default async function RegisterPage({ searchParams }: RegisterPageProps) {
+  const currentUser = await getCurrentUser();
+
+  if (currentUser) {
+    redirect("/app");
+  }
+
   const params = searchParams ? await searchParams : undefined;
   const status = params?.status;
   const errorCode = params?.error;

--- a/tests/e2e/auth-session-hardening.spec.ts
+++ b/tests/e2e/auth-session-hardening.spec.ts
@@ -1,0 +1,85 @@
+import { randomUUID } from "node:crypto";
+import { expect, test, type Page } from "@playwright/test";
+
+type Credentials = {
+  email: string;
+  password: string;
+};
+
+test("invalid session cookie is treated as unauthenticated on protected routes", async ({ page }) => {
+  await page.context().addCookies([
+    {
+      name: "wshka_session",
+      value: "invalid-session-token",
+      url: "http://127.0.0.1:3000",
+      httpOnly: true,
+      sameSite: "Lax",
+    },
+  ]);
+
+  await page.goto("/app");
+  await expect(page).toHaveURL(/\/login$/);
+  await expect(page.getByRole("heading", { name: "Вход" })).toBeVisible();
+
+  await page.goto("/app/reservations");
+  await expect(page).toHaveURL(/\/login$/);
+  await expect(page.getByRole("heading", { name: "Вход" })).toBeVisible();
+
+  await page.goto("/login");
+  await expect(page).toHaveURL(/\/login$/);
+  await expect(page.getByRole("heading", { name: "Вход" })).toBeVisible();
+});
+
+test("authenticated users are redirected away from auth pages and logout revokes protected access", async ({ page }) => {
+  const credentials = createCredentials();
+
+  await registerUser(page, credentials);
+  await loginUser(page, credentials);
+
+  await page.goto("/login");
+  await expect(page).toHaveURL(/\/app(?:\?.*)?$/);
+  await expect(page.getByRole("heading", { name: "Мой вишлист" })).toBeVisible();
+
+  await page.goto("/register");
+  await expect(page).toHaveURL(/\/app(?:\?.*)?$/);
+  await expect(page.getByRole("heading", { name: "Мой вишлист" })).toBeVisible();
+
+  await page.getByRole("button", { name: "Выйти" }).click();
+  await expect(page).toHaveURL(/\/login\?status=logged-out$/);
+  await expect(page.getByText("Вы вышли из аккаунта.")).toBeVisible();
+
+  await page.goto("/app");
+  await expect(page).toHaveURL(/\/login$/);
+  await expect(page.getByRole("heading", { name: "Вход" })).toBeVisible();
+
+  await page.goto("/app/reservations");
+  await expect(page).toHaveURL(/\/login$/);
+  await expect(page.getByRole("heading", { name: "Вход" })).toBeVisible();
+});
+
+function createCredentials(): Credentials {
+  const runId = randomUUID().slice(0, 12);
+
+  return {
+    email: `auth-hardening-${runId}@example.com`,
+    password: `AuthHardening!${runId}`,
+  };
+}
+
+async function registerUser(page: Page, credentials: Credentials) {
+  await page.goto("/register");
+  await expect(page.getByRole("heading", { name: "Регистрация" })).toBeVisible();
+  await page.getByLabel("Email").fill(credentials.email);
+  await page.getByLabel("Пароль").fill(credentials.password);
+  await page.getByRole("button", { name: "Создать аккаунт" }).click();
+  await expect(page).toHaveURL(/\/register\?status=success$/);
+}
+
+async function loginUser(page: Page, credentials: Credentials) {
+  await page.goto("/login");
+  await expect(page.getByRole("heading", { name: "Вход" })).toBeVisible();
+  await page.getByLabel("Email").fill(credentials.email);
+  await page.getByLabel("Пароль").fill(credentials.password);
+  await page.getByRole("button", { name: "Войти" }).click();
+  await expect(page).toHaveURL(/\/app(?:\?.*)?$/);
+}

--- a/tests/unit/auth-page-behavior.test.ts
+++ b/tests/unit/auth-page-behavior.test.ts
@@ -1,0 +1,74 @@
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const redirectSignal = new Error("redirect");
+
+const mocks = vi.hoisted(() => ({
+  getCurrentUser: vi.fn(),
+  redirect: vi.fn(() => {
+    throw redirectSignal;
+  }),
+}));
+
+vi.mock("next/navigation", () => ({
+  redirect: mocks.redirect,
+}));
+
+vi.mock("../../src/modules/auth/server/current-user", () => ({
+  getCurrentUser: mocks.getCurrentUser,
+}));
+
+describe("auth page behavior", () => {
+  beforeEach(() => {
+    Object.assign(globalThis, { React });
+    mocks.getCurrentUser.mockReset();
+    mocks.redirect.mockClear();
+  });
+
+  it("redirects authenticated users away from /login", async () => {
+    mocks.getCurrentUser.mockResolvedValue({
+      id: "user-1",
+      email: "user@example.com",
+    });
+
+    const { default: LoginPage } = await import("../../src/app/login/page");
+
+    await expect(LoginPage({})).rejects.toThrow(redirectSignal);
+    expect(mocks.redirect).toHaveBeenCalledWith("/app");
+  });
+
+  it("redirects authenticated users away from /register", async () => {
+    mocks.getCurrentUser.mockResolvedValue({
+      id: "user-1",
+      email: "user@example.com",
+    });
+
+    const { default: RegisterPage } = await import("../../src/app/register/page");
+
+    await expect(RegisterPage({})).rejects.toThrow(redirectSignal);
+    expect(mocks.redirect).toHaveBeenCalledWith("/app");
+  });
+
+  it("renders the login form for unauthenticated users", async () => {
+    mocks.getCurrentUser.mockResolvedValue(null);
+
+    const { default: LoginPage } = await import("../../src/app/login/page");
+    const page = await LoginPage({});
+    const html = renderToStaticMarkup(page);
+
+    expect(html).toContain("Вход");
+    expect(html).toContain("Войти");
+  });
+
+  it("renders the register form for unauthenticated users", async () => {
+    mocks.getCurrentUser.mockResolvedValue(null);
+
+    const { default: RegisterPage } = await import("../../src/app/register/page");
+    const page = await RegisterPage({});
+    const html = renderToStaticMarkup(page);
+
+    expect(html).toContain("Регистрация");
+    expect(html).toContain("Создать аккаунт");
+  });
+});


### PR DESCRIPTION
Closes #96 

Harden auth/session behavior and route consistency before v1.0.0 by fixing an authenticated auth-page bug and adding focused coverage for session edge cases and protected route behavior.

## What changed

* fixed authenticated user behavior on auth pages:
  * `/login` now redirects to `/app` if a valid session exists
  * `/register` now redirects to `/app` if a valid session exists
* ensured consistent protected route behavior:
  * `/app` and `/app/reservations` now behave identically for invalid or missing sessions
* strengthened session hardening coverage:
  * invalid session cookie handling
  * logout access revocation
  * authenticated access to auth pages
* added focused test coverage:
  * unit tests for auth-page behavior
  * e2e tests for session validity, redirects, and logout flows

## How to verify

* run unit tests:
  * `npx vitest run tests/unit/auth-current-user.test.ts tests/unit/auth-route-guards.test.ts tests/unit/auth-logout.test.ts tests/unit/auth-page-behavior.test.ts`
* run e2e tests:
  * `npx playwright test tests/e2e/auth-guards.spec.ts tests/e2e/auth-session-hardening.spec.ts`
* manual checks:
  * login and try to access `/login` or `/register` → should redirect to `/app`
  * clear or corrupt `wshka_session` cookie and open `/app` → should redirect to `/login`
  * login → logout → try to access `/app` again → should be blocked/redirected
  * confirm `/app` and `/app/reservations` behave consistently in all cases

## Tests

* added:
  * `tests/unit/auth-page-behavior.test.ts`
  * `tests/e2e/auth-session-hardening.spec.ts`
* existing auth-related unit and e2e tests remain valid and pass
* all tests pass:
  * `npm run typecheck`
  * `vitest` unit suite
  * `playwright` targeted e2e suite

## Documentation

* no additional documentation changes required for this PR