### PR TITLE
chore(release): validate runtime matrix, docker delivery, and rollback readiness

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Create a wishlist, share it by link, and let another person reserve an item.
 - Current-user reservations page and cancel flow on `/app/reservations`.
 - Focused reservation coverage across helper logic and owner/public/reserver routes.
 - Runtime env and deploy contract for local, CI, and production.
-- Production `Next.js standalone` image build through the repository `Dockerfile`.
+- Production `Next.js standalone` image build through `ops/Dockerfile`.
 - Production-oriented Docker Compose stack for `app`, `postgres`, and `caddy`.
 - Caddy reverse proxy and HTTPS foundation for `wshka.ru`.
 - GHCR image publish on `main` and SemVer tag pushes.

--- a/compose.yaml
+++ b/compose.yaml
@@ -22,6 +22,7 @@ services:
     image: ${APP_IMAGE:-wshka-app:local}
     build:
       context: .
+      dockerfile: ops/Dockerfile
     restart: unless-stopped
     depends_on:
       postgres:

--- a/docs/delivery-validation.md
+++ b/docs/delivery-validation.md
@@ -32,7 +32,7 @@
   - push to `main`
   - push of `v*.*.*` tags
 - Source-of-truth image build path:
-  - repository `Dockerfile`
+  - `ops/Dockerfile`
 - Expected GHCR tags:
   - every publish run: `sha-<full-commit-sha>`
   - default branch publish: `main`
@@ -85,7 +85,7 @@ How to validate in GHCR:
 What success looks like:
 - the package exists in GHCR
 - the expected tag is present
-- the publish workflow did not rebuild through any path other than the repository `Dockerfile`
+- the publish workflow did not rebuild through any path other than `ops/Dockerfile`
 
 ### 3. Deploy Validation On VPS
 How deploy is triggered:

--- a/docs/runtime-environment.md
+++ b/docs/runtime-environment.md
@@ -83,7 +83,7 @@
 ## GitHub Actions Publish Flow
 - PR build validation is handled by `.github/workflows/baseline-pr-validation.yml`.
 - GHCR image publish is handled by `.github/workflows/image-publish.yml`.
-- The publish workflow uses the existing production `Dockerfile` from `M6-I2`.
+- The publish workflow uses the existing production `ops/Dockerfile` from `M6-I2`.
 - Publish events are:
   - push to `main`
   - push of SemVer tags matching `v*.*.*`
@@ -162,7 +162,7 @@
 - Local verification without Compose should use a container-specific env file when the database stays on the host machine.
 - `.env.docker.example` documents the expected host alias pattern for that case.
 - Local verification commands:
-  - `docker build -t wshka-app .`
+  - `docker build -f ops/Dockerfile -t wshka-app .`
   - `docker run -p 3000:3000 --env-file .env.docker.local wshka-app`
 
 ## Compose Stack Foundation

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "rm -rf .next && next dev",
     "build": "next build",
     "start": "rm -rf .next/standalone/.next/static && mkdir -p .next/standalone/.next/static && cp -R .next/static/. .next/standalone/.next/static && cp -R public/. .next/standalone/public && node --env-file-if-exists=.env.local .next/standalone/server.js",
     "db:generate": "drizzle-kit generate --config config/drizzle.config.ts",

--- a/tests/e2e/auth-session-hardening.spec.ts
+++ b/tests/e2e/auth-session-hardening.spec.ts
@@ -41,6 +41,8 @@ test("authenticated users are redirected away from auth pages and logout revokes
 
   await page.getByRole("button", { name: "Выйти" }).click();
   await expect(page).toHaveURL(/\/(?:\?.*)?$/);
+  await expect(page.getByRole("button", { name: "Выйти" })).toHaveCount(0);
+  await expect(page.getByRole("link", { name: "Войти" }).first()).toBeVisible();
 
   await page.goto("/reservations");
   await expect(page).toHaveURL(/\/login$/);


### PR DESCRIPTION
Closes #98 

Production release rehearsal performed to validate that the current application state can be reliably built, deployed, executed, and rolled back in production-like environments without breaking core user flows.

## What changed

* validated full runtime matrix across all supported execution paths:

  * unit tests, typecheck, DB migrations, e2e
  * local dev and production-like runs
  * single-container Docker run
  * Docker Compose (app + postgres + reverse proxy)
* fixed dev/runtime inconsistency after production build:

  * ensured `.next` is cleaned before `next dev` to avoid ENOENT runtime errors
* aligned Docker delivery configuration:

  * fixed `compose.yaml` to use `ops/Dockerfile`
  * synchronized runtime and delivery documentation with actual build path
* stabilized flaky auth/session e2e verification:

  * logout flow now waits for guest state before asserting protected route access
* added/updated delivery and runtime documentation:

  * clarified environment contract and execution paths
  * documented release validation expectations

## How to verify

* run full validation locally:

  ```bash
  npm ci
  DATABASE_URL=... npm run db:migrate
  npm run typecheck
  npm run test:unit
  DATABASE_URL=... npm run test:e2e
  npm run build
  npm run start
  ```

* verify core routes manually:

  * `/`
  * `/login`
  * `/register`
  * `/reservations`
  * `/share/[token]`
  * `/healthz`

* validate Docker paths:

  ```bash
  docker build -f ops/Dockerfile -t wshka-app:test .
  docker run -p 3000:3000 -e DATABASE_URL=... wshka-app:test
  ```

* validate Docker Compose:

  ```bash
  docker compose build app
  docker compose up -d postgres
  docker compose run --rm app node /app/ops/deploy/run-migrations.mjs
  docker compose up -d app caddy
  ```

* validate rollback scenario:

  * run current build and create sample data (users, items, reservations, share link)
  * checkout previous stable commit
  * rebuild and run against the same DB
  * verify:

    * app starts
    * sessions remain valid
    * reservations and share links are intact

## Tests

* `npm run typecheck`
* `npm run test:unit`
* `npm run test:e2e`
* manual production-like verification via Node and headless browser
* Docker and Docker Compose runtime validation

## Documentation

* updated runtime and delivery documentation to reflect actual deployment path
* added release validation notes and expectations

---

## Notes

* release and rollback paths are operationally verified and stable
* core user flows work in production-like environments
* known limitation:

  * build artifacts are not fully reproducible byte-to-byte between clean builds
  * treated as a non-blocking risk for v1.0.0
