### PR TITLE
feat(reservation): allow owners to reserve their own wishlist items

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,5 @@ pnpm-debug.log*
 
 # local docs
 docs/COMMANDS.md
+.claude/
+CLAUDE.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on Keep a Changelog, and this project follows SemVer.
 
 ## [Unreleased]
 
+### Added
+- Owners can now reserve their own wishlist items from the dashboard and
+  the share page. Self-reserved items are visually distinct on the dashboard
+  and the reservations page.
+
 ## [1.0.1] - 2026-04-23
 
 ### Added

--- a/src/app/_dashboard/cancel-item-reservation-button.tsx
+++ b/src/app/_dashboard/cancel-item-reservation-button.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { useEffect, useActionState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import type { CancelItemReservationState } from "./item-actions";
+
+function XIcon() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+      strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <line x1="18" y1="6" x2="6" y2="18" />
+      <line x1="6" y1="6" x2="18" y2="18" />
+    </svg>
+  );
+}
+
+type CancelItemReservationButtonProps = {
+  reservationId: string;
+  cancelLabel: string;
+  cancelAction: (
+    prev: CancelItemReservationState,
+    formData: FormData,
+  ) => Promise<CancelItemReservationState>;
+};
+
+export function CancelItemReservationButton({
+  reservationId,
+  cancelLabel,
+  cancelAction,
+}: CancelItemReservationButtonProps) {
+  const router = useRouter();
+  const [, startTransition] = useTransition();
+  const [state, formAction] = useActionState(cancelAction, null);
+
+  useEffect(() => {
+    if (state?.status === "success") {
+      startTransition(() => router.refresh());
+    }
+  }, [state]);
+
+  return (
+    <form action={formAction}>
+      <input type="hidden" name="reservationId" value={reservationId} />
+      <button type="submit" className="item-cancel-reservation-btn">
+        <XIcon />
+        <span className="item-btn-label">{cancelLabel}</span>
+      </button>
+    </form>
+  );
+}

--- a/src/app/_dashboard/item-actions.ts
+++ b/src/app/_dashboard/item-actions.ts
@@ -23,6 +23,16 @@ export type DeleteItemState = {
   error?: string;
 } | null;
 
+export type ReserveItemState = {
+  status: "success" | "error";
+  error?: string;
+} | null;
+
+export type CancelItemReservationState = {
+  status: "success" | "error";
+  error?: string;
+} | null;
+
 export type RegenerateState = {
   status: "success" | "error";
 } | null;

--- a/src/app/_dashboard/item-edit-section.tsx
+++ b/src/app/_dashboard/item-edit-section.tsx
@@ -13,11 +13,12 @@ function PencilIcon() {
 
 type ItemEditSectionProps = {
   editLabel: string;
+  reserveButton?: React.ReactNode;
   deleteButton: React.ReactNode;
   children: React.ReactNode;
 };
 
-export function ItemEditSection({ editLabel, deleteButton, children }: ItemEditSectionProps) {
+export function ItemEditSection({ editLabel, reserveButton, deleteButton, children }: ItemEditSectionProps) {
   const [open, setOpen] = useState(false);
   const sectionRef = useRef<HTMLDivElement>(null);
   const formAreaRef = useRef<HTMLDivElement>(null);
@@ -32,17 +33,24 @@ export function ItemEditSection({ editLabel, deleteButton, children }: ItemEditS
   return (
     <div ref={sectionRef} className="item-edit-section">
       <div className="item-card-footer">
-        <button
-          type="button"
-          className="item-edit-btn"
-          data-testid="edit-item-toggle"
-          aria-expanded={open}
-          onClick={() => setOpen((v) => !v)}
-        >
-          <PencilIcon />
-          <span className="item-btn-label">{editLabel}</span>
-        </button>
-        {deleteButton}
+        <div className="item-footer-start">
+          <button
+            type="button"
+            className="item-edit-btn"
+            data-testid="edit-item-toggle"
+            aria-expanded={open}
+            onClick={() => setOpen((v) => !v)}
+          >
+            <PencilIcon />
+            <span className="item-btn-label">{editLabel}</span>
+          </button>
+        </div>
+        <div className="item-footer-center">
+          {reserveButton}
+        </div>
+        <div className="item-footer-end">
+          {deleteButton}
+        </div>
       </div>
       {open && (
         <div ref={formAreaRef} className="item-edit-form-inner">

--- a/src/app/_dashboard/reserve-item-button.tsx
+++ b/src/app/_dashboard/reserve-item-button.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { useEffect, useActionState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import type { ReserveItemState } from "./item-actions";
+
+function BookmarkIcon() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+      strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <path d="M19 21l-7-5-7 5V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z" />
+    </svg>
+  );
+}
+
+type ReserveItemButtonProps = {
+  itemId: string;
+  reserveLabel: string;
+  reserveAction: (prev: ReserveItemState, formData: FormData) => Promise<ReserveItemState>;
+};
+
+export function ReserveItemButton({
+  itemId,
+  reserveLabel,
+  reserveAction,
+}: ReserveItemButtonProps) {
+  const router = useRouter();
+  const [, startTransition] = useTransition();
+  const [state, formAction] = useActionState(reserveAction, null);
+
+  useEffect(() => {
+    if (state?.status === "success") {
+      startTransition(() => router.refresh());
+    }
+  }, [state]);
+
+  return (
+    <form action={formAction}>
+      <input type="hidden" name="itemId" value={itemId} />
+      <button type="submit" className="item-reserve-btn">
+        <BookmarkIcon />
+        <span className="item-btn-label">{reserveLabel}</span>
+      </button>
+    </form>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,11 +7,13 @@ import {
   getOrCreateCurrentShareLink,
   regenerateCurrentShareLink,
 } from "@/modules/share";
-import type { DeleteItemState, RegenerateState } from "./_dashboard/item-actions";
-import { getCurrentOwnerWishlistWithReservations } from "@/modules/reservation";
+import type { DeleteItemState, RegenerateState, ReserveItemState, CancelItemReservationState } from "./_dashboard/item-actions";
+import { getCurrentOwnerWishlistWithReservations, createReservation, cancelReservation } from "@/modules/reservation";
 import { deleteCurrentWishlistItem } from "@/modules/wishlist/server/manage-item";
 import { OpenFormButton, AddItemFormFocus } from "./_dashboard/open-form-button";
 import { DeleteItemButton } from "./_dashboard/delete-item-button";
+import { ReserveItemButton } from "./_dashboard/reserve-item-button";
+import { CancelItemReservationButton } from "./_dashboard/cancel-item-reservation-button";
 import { ItemEditSection } from "./_dashboard/item-edit-section";
 import { CopyUrlButton } from "./_dashboard/copy-url-button";
 import { CreateItemForm } from "./_dashboard/create-item-form";
@@ -225,9 +227,11 @@ async function DashboardView({ userId }: { userId: string }) {
               <li key={item.id} className="item-card">
                 {/* Status strip */}
                 {item.reservation.status === "reserved" ? (
-                  <div className="item-card-status item-card-status-reserved">
+                  <div className={`item-card-status ${item.reservation.isOwn ? "item-card-status-self-reserved" : "item-card-status-reserved"}`}>
                     <span className="item-card-status-dot" />
-                    {messages.dashboard.itemReservation.reservedLabel}
+                    {item.reservation.isOwn
+                      ? messages.dashboard.itemReservation.selfReservedLabel
+                      : messages.dashboard.itemReservation.reservedLabel}
                   </div>
                 ) : (
                   <div className="item-card-status item-card-status-available">
@@ -268,9 +272,24 @@ async function DashboardView({ userId }: { userId: string }) {
                   </div>
                 </div>
 
-                {/* Footer: edit toggle + delete */}
+                {/* Footer: edit toggle + reserve + delete */}
                 <ItemEditSection
                   editLabel={messages.dashboard.editToggleLabel}
+                  reserveButton={
+                    item.reservation.status === "available" ? (
+                      <ReserveItemButton
+                        itemId={item.id}
+                        reserveLabel={messages.dashboard.reserveLabel}
+                        reserveAction={reserveItemAction}
+                      />
+                    ) : item.reservation.isOwn ? (
+                      <CancelItemReservationButton
+                        reservationId={item.reservation.reservationId}
+                        cancelLabel={messages.dashboard.cancelReservationLabel}
+                        cancelAction={cancelItemReservationAction}
+                      />
+                    ) : undefined
+                  }
                   deleteButton={
                     <DeleteItemButton
                       itemId={item.id}
@@ -319,6 +338,32 @@ async function deleteItemAction(
 
   const user = await requireCurrentUser();
   const result = await deleteCurrentWishlistItem(user.id, getFormValue(formData, "itemId"));
+
+  if (result.status === "success") return { status: "success" };
+  return { status: "error", error: result.code };
+}
+
+async function reserveItemAction(
+  prev: ReserveItemState,
+  formData: FormData,
+): Promise<ReserveItemState> {
+  "use server";
+
+  const user = await requireCurrentUser();
+  const result = await createReservation(user.id, getFormValue(formData, "itemId"));
+
+  if (result.status === "success") return { status: "success" };
+  return { status: "error", error: result.code };
+}
+
+async function cancelItemReservationAction(
+  prev: CancelItemReservationState,
+  formData: FormData,
+): Promise<CancelItemReservationState> {
+  "use server";
+
+  const user = await requireCurrentUser();
+  const result = await cancelReservation(user.id, getFormValue(formData, "reservationId"));
 
   if (result.status === "success") return { status: "success" };
   return { status: "error", error: result.code };

--- a/src/app/reservations/page.tsx
+++ b/src/app/reservations/page.tsx
@@ -74,9 +74,14 @@ export default async function ReservationsPage(props: ReservationsPageProps) {
                 className="reservation-card"
                 data-testid="reservation-card"
               >
-                <div className="item-card-status item-card-status-reserved">
+                <div className={`item-card-status ${reservation.isOwnItem ? "item-card-status-self-reserved" : "item-card-status-reserved"}`}>
                   <span className="item-card-status-dot" />
                   {messages.dashboard.itemReservation.reservedLabel}
+                  {reservation.isOwnItem ? (
+                    <span className="item-own-badge">
+                      {messages.reservations.ownItemBadge}
+                    </span>
+                  ) : null}
                 </div>
                 <div className="reservation-card-body">
                   <h3 className="reservation-card-title">{reservation.item.title}</h3>

--- a/src/app/share/[token]/actions.ts
+++ b/src/app/share/[token]/actions.ts
@@ -39,8 +39,6 @@ export async function reservePublicWishlistItemAction(formData: FormData) {
   switch (result.code) {
     case "already-reserved":
       redirect(`${sharePath}?action=reserve&error=already-reserved`);
-    case "own-item":
-      redirect(`${sharePath}?action=reserve&error=own-item`);
     case "item-not-found":
       redirect(`${sharePath}?action=reserve&error=invalid-share`);
     default:

--- a/src/app/share/[token]/page.tsx
+++ b/src/app/share/[token]/page.tsx
@@ -290,8 +290,7 @@ function SharePageView({
                   </div>
                 ) : null}
                 {item.reservation.status !== "reserved" &&
-                wishlist.viewer.isAuthenticated &&
-                !wishlist.viewer.isOwner ? (
+                wishlist.viewer.isAuthenticated ? (
                   <form action={reservePublicWishlistItemAction}>
                     <input type="hidden" name="token" value={wishlist.shareLink.token} />
                     <input type="hidden" name="itemId" value={item.id} />
@@ -317,8 +316,6 @@ function getShareActionErrorMessage(action: string | undefined, errorCode: strin
   switch (errorCode) {
     case "already-reserved":
       return messages.share.errors.alreadyReserved;
-    case "own-item":
-      return messages.share.errors.ownItem;
     case "invalid-share":
       return messages.share.errors.invalidShare;
     default:

--- a/src/app/styles/dashboard.css
+++ b/src/app/styles/dashboard.css
@@ -248,12 +248,28 @@
     border-bottom-color: #e9d5ff;
   }
 
+  .item-card-status-self-reserved {
+    background: #dbeafe;
+    color: #1d4ed8;
+    border-bottom-color: #bfdbfe;
+  }
+
   .item-card-status-dot {
     width: 6px;
     height: 6px;
     border-radius: 50%;
     flex-shrink: 0;
     background: currentColor;
+  }
+
+  .item-own-badge {
+    margin-left: var(--space-2);
+    padding: 1px var(--space-2);
+    border-radius: var(--radius-sm);
+    background: #bfdbfe;
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: #1d4ed8;
   }
 
   .item-card-view {
@@ -337,11 +353,28 @@
   .item-card-footer {
     display: flex;
     align-items: center;
-    gap: var(--space-3);
     padding: var(--space-3) var(--space-4);
     border-top: 1px solid var(--color-border-soft);
     background: var(--color-bg-subtle);
     overflow: hidden;
+  }
+
+  .item-footer-start {
+    flex: 1;
+    display: flex;
+  }
+
+  .item-footer-center {
+    display: flex;
+    justify-content: center;
+    flex-shrink: 0;
+    padding: 0 var(--space-2);
+  }
+
+  .item-footer-end {
+    flex: 1;
+    display: flex;
+    justify-content: flex-end;
   }
 
   .item-edit-btn {
@@ -372,6 +405,52 @@
     border-color: var(--color-accent);
     color: var(--color-accent);
     background: var(--color-accent-surface);
+  }
+
+  .item-reserve-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: var(--space-2);
+    border: 1px solid var(--color-border-strong);
+    border-radius: var(--radius-md);
+    background: var(--color-bg-surface);
+    padding: var(--space-3) var(--space-4);
+    color: var(--color-accent);
+    font: inherit;
+    font-size: var(--font-size-label);
+    font-weight: 600;
+    cursor: pointer;
+    white-space: nowrap;
+    flex-shrink: 0;
+  }
+
+  .item-reserve-btn:hover {
+    border-color: var(--color-accent);
+    background: var(--color-accent-surface);
+  }
+
+  .item-cancel-reservation-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: var(--space-2);
+    border: 1px solid #bfdbfe;
+    border-radius: var(--radius-md);
+    background: #eff6ff;
+    padding: var(--space-3) var(--space-4);
+    color: #1d4ed8;
+    font: inherit;
+    font-size: var(--font-size-label);
+    font-weight: 600;
+    cursor: pointer;
+    white-space: nowrap;
+    flex-shrink: 0;
+  }
+
+  .item-cancel-reservation-btn:hover {
+    border-color: #93c5fd;
+    background: #dbeafe;
   }
 
   .item-delete-btn {
@@ -411,6 +490,8 @@
     }
 
     .item-edit-btn,
+    .item-reserve-btn,
+    .item-cancel-reservation-btn,
     .item-delete-btn {
       padding: var(--space-3);
       min-width: 4.5rem;

--- a/src/modules/i18n/dictionaries/ru/app.ts
+++ b/src/modules/i18n/dictionaries/ru/app.ts
@@ -164,6 +164,8 @@ export const app = {
     deleteConfirmLabel: "Да, удалить",
     deleteCancelLabel: "Отмена",
     editToggleLabel: "Редактировать",
+    reserveLabel: "Забронировать",
+    cancelReservationLabel: "Отменить",
     summaryLabel: "Текущий вишлист",
     itemCountForms: ["желание", "желания", "желаний"] as [string, string, string],
     successMessage: "Желание добавлено.",
@@ -216,6 +218,7 @@ export const app = {
     itemReservation: {
       availableLabel: "Статус: доступно",
       reservedLabel: "Статус: забронировано",
+      selfReservedLabel: "Статус: забронировано мной",
     },
   },
   reservations: {
@@ -227,6 +230,7 @@ export const app = {
     emptyActionLabel: "Вернуться к вишлисту",
     cancelLabel: "Отменить бронь",
     cancelSuccessMessage: "Бронь отменена.",
+    ownItemBadge: "Моё желание",
     errors: {
       reservationNotFound: "Не удалось найти активную бронь для отмены.",
       notReservationOwner: "Можно отменить только свою активную бронь.",
@@ -250,13 +254,12 @@ export const app = {
     itemsTitle: "Желания",
     guestHint: "Войдите, чтобы забронировать доступное желание и потом управлять бронями в своём разделе.",
     loginToReserveLabel: "Войти, чтобы забронировать",
-    ownerHint: "Это ваш вишлист. Здесь можно только проверить, как он выглядит по публичной ссылке.",
+    ownerHint: "Это ваш вишлист. Здесь можно проверить, как он выглядит, и забронировать желания, которые уже исполнены.",
     reserveLabel: "Забронировать",
     reservedLabel: "Уже забронировано",
     successMessage: "Желание забронировано.",
     errors: {
       alreadyReserved: "Это желание уже забронировано. Обновите страницу или выберите другой подарок.",
-      ownItem: "Нельзя забронировать желание из собственного вишлиста.",
       invalidShare: "Не удалось забронировать желание по этой ссылке.",
       unknown: "Не удалось забронировать желание. Попробуйте ещё раз.",
     },

--- a/src/modules/reservation/server/current-user-reservations.ts
+++ b/src/modules/reservation/server/current-user-reservations.ts
@@ -1,6 +1,6 @@
 import { and, asc, eq, inArray, isNull } from "drizzle-orm";
 import { reservations } from "@/modules/reservation/db/schema";
-import { wishlistItems } from "@/modules/wishlist/db/schema";
+import { wishlistItems, wishlists } from "@/modules/wishlist/db/schema";
 
 export type CurrentUserReservationItem = {
   id: string;
@@ -16,6 +16,7 @@ export type CurrentUserReservationItem = {
 export type CurrentUserReservation = {
   id: string;
   createdAt: Date;
+  isOwnItem: boolean;
   item: CurrentUserReservationItem;
 };
 
@@ -57,6 +58,18 @@ export async function listCurrentUserActiveReservations(
 
   const itemsById = new Map(items.map((item) => [item.id, item]));
 
+  const wishlistIds = [...new Set(items.map((item) => item.wishlistId))];
+  const ownWishlistIds = new Set(
+    wishlistIds.length > 0
+      ? (
+          await db.query.wishlists.findMany({
+            columns: { id: true },
+            where: and(inArray(wishlists.id, wishlistIds), eq(wishlists.userId, userId)),
+          })
+        ).map((w) => w.id)
+      : [],
+  );
+
   return activeReservations.flatMap((reservation) => {
     const item = itemsById.get(reservation.wishlistItemId);
 
@@ -67,6 +80,7 @@ export async function listCurrentUserActiveReservations(
     return {
       id: reservation.id,
       createdAt: reservation.createdAt,
+      isOwnItem: ownWishlistIds.has(item.wishlistId),
       item,
     };
   });

--- a/src/modules/reservation/server/lifecycle.ts
+++ b/src/modules/reservation/server/lifecycle.ts
@@ -22,7 +22,7 @@ export type ReservationEligibility =
   | { status: "eligible" }
   | {
       status: "ineligible";
-      code: "item-not-found" | "already-reserved" | "own-item";
+      code: "item-not-found" | "already-reserved";
     };
 
 export type CreateReservationResult =
@@ -32,7 +32,7 @@ export type CreateReservationResult =
     }
   | {
       status: "error";
-      code: "item-not-found" | "already-reserved" | "own-item" | "unknown";
+      code: "item-not-found" | "already-reserved" | "unknown";
     };
 
 export type CancelReservationResult =
@@ -146,10 +146,6 @@ export async function getItemReservationEligibility(
     return { status: "ineligible", code: "item-not-found" };
   }
 
-  if (itemContext.ownerUserId === userId) {
-    return { status: "ineligible", code: "own-item" };
-  }
-
   const activeReservation = await getActiveReservationByItemId(itemContext.itemId);
 
   if (activeReservation) {
@@ -168,10 +164,6 @@ export async function createReservation(
 
     if (!itemContext) {
       return { status: "error", code: "item-not-found" };
-    }
-
-    if (itemContext.ownerUserId === userId) {
-      return { status: "error", code: "own-item" };
     }
 
     const activeReservation = await getActiveReservationByItemId(itemContext.itemId);

--- a/src/modules/reservation/server/owner-wishlist.ts
+++ b/src/modules/reservation/server/owner-wishlist.ts
@@ -4,9 +4,10 @@ import {
 } from "@/modules/wishlist/server/items";
 import { listActiveReservationsByItemIds } from "@/modules/reservation/server/lifecycle";
 
-export type OwnerWishlistItemReservation = {
-  status: "available" | "reserved";
-};
+export type OwnerWishlistItemReservation =
+  | { status: "available" }
+  | { status: "reserved"; isOwn: false }
+  | { status: "reserved"; isOwn: true; reservationId: string };
 
 export type OwnerWishlistItem = WishlistWithItems["items"][number] & {
   reservation: OwnerWishlistItemReservation;
@@ -20,19 +21,30 @@ export async function getCurrentOwnerWishlistWithReservations(
   userId: string,
 ): Promise<OwnerWishlistWithReservations> {
   const wishlist = await getCurrentWishlistWithItems(userId);
-  const activeReservationItemIds = new Set(
-    (await listActiveReservationsByItemIds(wishlist.items.map((item) => item.id))).map(
-      (reservation) => reservation.wishlistItemId,
-    ),
+  const activeReservations = await listActiveReservationsByItemIds(
+    wishlist.items.map((item) => item.id),
+  );
+  const activeReservationByItemId = new Map(
+    activeReservations.map((r) => [r.wishlistItemId, r]),
   );
 
   return {
     ...wishlist,
-    items: wishlist.items.map((item) => ({
-      ...item,
-      reservation: {
-        status: activeReservationItemIds.has(item.id) ? "reserved" : "available",
-      },
-    })),
+    items: wishlist.items.map((item) => {
+      const reservation = activeReservationByItemId.get(item.id);
+
+      if (!reservation) {
+        return { ...item, reservation: { status: "available" } };
+      }
+
+      const isOwn = reservation.userId === userId;
+
+      return {
+        ...item,
+        reservation: isOwn
+          ? { status: "reserved", isOwn: true, reservationId: reservation.id }
+          : { status: "reserved", isOwn: false },
+      };
+    }),
   };
 }

--- a/tests/e2e/owner-journey.spec.ts
+++ b/tests/e2e/owner-journey.spec.ts
@@ -95,7 +95,7 @@ test("owner can complete the core wishlist journey end to end", async ({ page })
     await expect(sharePreviewPage.getByRole("heading", { name: "Публичный вишлист" })).toBeVisible();
     await expect(
       sharePreviewPage.getByText(
-        "Это ваш вишлист. Здесь можно только проверить, как он выглядит по публичной ссылке.",
+        "Это ваш вишлист. Здесь можно проверить, как он выглядит, и забронировать желания, которые уже исполнены.",
       ),
     ).toBeVisible();
     await expect(sharePreviewPage.getByRole("heading", { name: updatedItem.title })).toBeVisible();
@@ -116,6 +116,32 @@ test("owner can complete the core wishlist journey end to end", async ({ page })
     await sharePreviewPage.goto(regeneratedShareUrl);
     await expect(sharePreviewPage.getByRole("heading", { name: "Публичный вишлист" })).toBeVisible();
     await expect(sharePreviewPage.getByRole("heading", { name: updatedItem.title })).toBeVisible();
+
+    await sharePreviewPage.close();
+  });
+
+  await test.step("owner can reserve their own item via the share page", async () => {
+    const shareUrl = await page.getByTestId("share-link-url").inputValue();
+    const sharePreviewPage = await page.context().newPage();
+
+    await sharePreviewPage.goto(shareUrl);
+
+    const itemCard = sharePreviewPage.getByTestId("share-item-card").filter({
+      has: sharePreviewPage.getByRole("heading", { name: updatedItem.title, exact: true }),
+    });
+
+    await expect(itemCard.getByRole("button", { name: "Забронировать" })).toBeVisible();
+    await itemCard.getByRole("button", { name: "Забронировать" }).click();
+
+    await expect(sharePreviewPage).toHaveURL(/\/share\/.*\?status=reservation-created$/);
+    await expect(sharePreviewPage.getByText("Желание забронировано.")).toBeVisible();
+
+    const reservedCard = sharePreviewPage.getByTestId("share-item-card").filter({
+      has: sharePreviewPage.getByRole("heading", { name: updatedItem.title, exact: true }),
+    });
+
+    await expect(reservedCard).toContainText("Уже забронировано");
+    await expect(reservedCard.getByRole("button", { name: "Забронировать" })).toHaveCount(0);
 
     await sharePreviewPage.close();
   });

--- a/tests/unit/reservation-current-user.test.ts
+++ b/tests/unit/reservation-current-user.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const mocks = vi.hoisted(() => ({
   findReservations: vi.fn(),
   findWishlistItems: vi.fn(),
+  findWishlists: vi.fn(),
 }));
 
 vi.mock("../../src/shared/db", () => ({
@@ -14,6 +15,9 @@ vi.mock("../../src/shared/db", () => ({
       wishlistItems: {
         findMany: mocks.findWishlistItems,
       },
+      wishlists: {
+        findMany: mocks.findWishlists,
+      },
     },
   },
 }));
@@ -24,6 +28,8 @@ describe("current user active reservations loading", () => {
   beforeEach(() => {
     mocks.findReservations.mockReset();
     mocks.findWishlistItems.mockReset();
+    mocks.findWishlists.mockReset();
+    mocks.findWishlists.mockResolvedValue([]);
   });
 
   it("returns only active reservations with item details for the current user", async () => {
@@ -51,6 +57,7 @@ describe("current user active reservations loading", () => {
       {
         id: "reservation-1",
         createdAt: new Date("2026-04-12T00:00:00.000Z"),
+        isOwnItem: false,
         item: {
           id: "item-1",
           wishlistId: "wishlist-1",
@@ -63,6 +70,33 @@ describe("current user active reservations loading", () => {
         },
       },
     ]);
+  });
+
+  it("marks isOwnItem as true when the reserved item belongs to the current user's wishlist", async () => {
+    mocks.findReservations.mockResolvedValue([
+      {
+        id: "reservation-1",
+        wishlistItemId: "item-1",
+        createdAt: new Date("2026-04-12T00:00:00.000Z"),
+      },
+    ]);
+    mocks.findWishlistItems.mockResolvedValue([
+      {
+        id: "item-1",
+        wishlistId: "wishlist-1",
+        title: "Наушники",
+        url: null,
+        note: null,
+        price: null,
+        createdAt: new Date("2026-04-11T00:00:00.000Z"),
+        updatedAt: new Date("2026-04-11T00:00:00.000Z"),
+      },
+    ]);
+    mocks.findWishlists.mockResolvedValue([{ id: "wishlist-1" }]);
+
+    const result = await listCurrentUserActiveReservations("user-1");
+
+    expect(result[0].isOwnItem).toBe(true);
   });
 
   it("returns an empty list when the current user has no active reservations", async () => {

--- a/tests/unit/reservation-lifecycle.test.ts
+++ b/tests/unit/reservation-lifecycle.test.ts
@@ -167,7 +167,7 @@ describe("reservation lifecycle helpers", () => {
     });
   });
 
-  it("blocks the owner from reserving their own item", async () => {
+  it("marks the owner as eligible when reserving their own available item", async () => {
     mocks.findWishlistItem.mockResolvedValue({
       id: "item-1",
       wishlistId: "wishlist-1",
@@ -176,12 +176,11 @@ describe("reservation lifecycle helpers", () => {
       id: "wishlist-1",
       userId: "owner-1",
     });
+    mocks.findReservation.mockResolvedValue(undefined);
 
     await expect(getItemReservationEligibility("owner-1", "item-1")).resolves.toEqual({
-      status: "ineligible",
-      code: "own-item",
+      status: "eligible",
     });
-    expect(mocks.findReservation).not.toHaveBeenCalled();
   });
 
   it("creates a reservation for an eligible non-owner item", async () => {
@@ -219,6 +218,44 @@ describe("reservation lifecycle helpers", () => {
     expect(mocks.insertValues).toHaveBeenCalledWith({
       wishlistItemId: "item-1",
       userId: "user-2",
+    });
+  });
+
+  it("creates a reservation when the owner reserves their own item", async () => {
+    const createdAt = new Date("2026-04-12T00:00:00.000Z");
+
+    mocks.findWishlistItem.mockResolvedValue({
+      id: "item-1",
+      wishlistId: "wishlist-1",
+    });
+    mocks.findWishlist.mockResolvedValue({
+      id: "wishlist-1",
+      userId: "owner-1",
+    });
+    mocks.findReservation.mockResolvedValue(undefined);
+    mocks.insertReturning.mockResolvedValue([
+      {
+        id: "reservation-2",
+        wishlistItemId: "item-1",
+        userId: "owner-1",
+        cancelledAt: null,
+        createdAt,
+      },
+    ]);
+
+    await expect(createReservation("owner-1", "item-1")).resolves.toEqual({
+      status: "success",
+      reservation: {
+        id: "reservation-2",
+        wishlistItemId: "item-1",
+        userId: "owner-1",
+        cancelledAt: null,
+        createdAt,
+      },
+    });
+    expect(mocks.insertValues).toHaveBeenCalledWith({
+      wishlistItemId: "item-1",
+      userId: "owner-1",
     });
   });
 

--- a/tests/unit/reservation-owner-wishlist.test.ts
+++ b/tests/unit/reservation-owner-wishlist.test.ts
@@ -77,9 +77,7 @@ describe("owner wishlist reservation-aware loading", () => {
           price: null,
           createdAt: new Date("2026-04-11T00:00:00.000Z"),
           updatedAt: new Date("2026-04-11T00:00:00.000Z"),
-          reservation: {
-            status: "available",
-          },
+          reservation: { status: "available" },
         },
         {
           id: "item-2",
@@ -90,12 +88,49 @@ describe("owner wishlist reservation-aware loading", () => {
           price: null,
           createdAt: new Date("2026-04-11T00:00:00.000Z"),
           updatedAt: new Date("2026-04-11T00:00:00.000Z"),
-          reservation: {
-            status: "reserved",
-          },
+          reservation: { status: "reserved", isOwn: false },
         },
       ],
     });
     expect(mocks.listActiveReservationsByItemIds).toHaveBeenCalledWith(["item-1", "item-2"]);
+  });
+
+  it("marks reservation as isOwn when the owner reserved their own item", async () => {
+    mocks.getCurrentWishlistWithItems.mockResolvedValue({
+      id: "wishlist-1",
+      userId: "owner-1",
+      isActive: true,
+      createdAt: new Date("2026-04-11T00:00:00.000Z"),
+      updatedAt: new Date("2026-04-11T00:00:00.000Z"),
+      items: [
+        {
+          id: "item-1",
+          wishlistId: "wishlist-1",
+          title: "Наушники",
+          url: null,
+          note: null,
+          price: null,
+          createdAt: new Date("2026-04-11T00:00:00.000Z"),
+          updatedAt: new Date("2026-04-11T00:00:00.000Z"),
+        },
+      ],
+    });
+    mocks.listActiveReservationsByItemIds.mockResolvedValue([
+      {
+        id: "reservation-1",
+        wishlistItemId: "item-1",
+        userId: "owner-1",
+        cancelledAt: null,
+        createdAt: new Date("2026-04-12T00:00:00.000Z"),
+      },
+    ]);
+
+    const result = await getCurrentOwnerWishlistWithReservations("owner-1");
+
+    expect(result.items[0].reservation).toEqual({
+      status: "reserved",
+      isOwn: true,
+      reservationId: "reservation-1",
+    });
   });
 });

--- a/tests/unit/reservations-page.test.ts
+++ b/tests/unit/reservations-page.test.ts
@@ -62,6 +62,7 @@ describe("current user reservations page", () => {
       {
         id: "reservation-1",
         createdAt: new Date("2026-04-12T00:00:00.000Z"),
+        isOwnItem: false,
         item: {
           id: "item-1",
           wishlistId: "wishlist-1",
@@ -86,6 +87,34 @@ describe("current user reservations page", () => {
     expect(html).toContain("Нужны беспроводные");
     expect(html).toContain("9\u00a0990");
     expect(html).toContain("Отменить бронь");
+    expect(html).not.toContain("Моё желание");
+  });
+
+  it("shows the own-item badge when the reservation is for the user's own wishlist", async () => {
+    mocks.listCurrentUserActiveReservations.mockResolvedValue([
+      {
+        id: "reservation-2",
+        createdAt: new Date("2026-04-12T00:00:00.000Z"),
+        isOwnItem: true,
+        item: {
+          id: "item-2",
+          wishlistId: "wishlist-1",
+          title: "Книга",
+          url: null,
+          note: null,
+          price: null,
+          createdAt: new Date("2026-04-11T00:00:00.000Z"),
+          updatedAt: new Date("2026-04-11T00:00:00.000Z"),
+        },
+      },
+    ]);
+
+    const { default: ReservationsPage } = await import("../../src/app/reservations/page");
+    const page = await ReservationsPage({});
+    const html = renderToStaticMarkup(page);
+
+    expect(html).toContain("Книга");
+    expect(html).toContain("Моё желание");
   });
 
   it("renders cancel success and error feedback", async () => {

--- a/tests/unit/share-page.test.ts
+++ b/tests/unit/share-page.test.ts
@@ -195,7 +195,7 @@ describe("public share route rendering", () => {
     expect(html).not.toContain("Уже забронировано");
   });
 
-  it("blocks reserve controls for the wishlist owner", async () => {
+  it("shows reserve controls for the wishlist owner on their own share page", async () => {
     mocks.getCurrentUser.mockResolvedValue({
       id: "owner-1",
       email: "owner@example.com",
@@ -234,9 +234,9 @@ describe("public share route rendering", () => {
     const html = renderToStaticMarkup(page);
 
     expect(html).toContain(
-      "Это ваш вишлист. Здесь можно только проверить, как он выглядит по публичной ссылке.",
+      "Это ваш вишлист. Здесь можно проверить, как он выглядит, и забронировать желания, которые уже исполнены.",
     );
-    expect(html).not.toContain("Забронировать</button>");
+    expect(html).toContain("Забронировать</button>");
   });
 
   it("shows reserved state instead of reserve controls for reserved items", async () => {
@@ -402,7 +402,7 @@ describe("public share route rendering", () => {
     expect(mocks.createReservation).not.toHaveBeenCalled();
   });
 
-  it("blocks reserve action for owner and already-reserved results", async () => {
+  it("redirects with already-reserved error when the item is taken", async () => {
     mocks.getCurrentUser.mockResolvedValue({
       id: "user-2",
       email: "user@example.com",
@@ -428,23 +428,13 @@ describe("public share route rendering", () => {
 
     const { reservePublicWishlistItemAction } = await import("../../src/app/share/[token]/actions");
 
-    const ownerFormData = new FormData();
-    ownerFormData.set("token", "opaque-token");
-    ownerFormData.set("itemId", "item-1");
-    mocks.createReservation.mockResolvedValueOnce({ status: "error", code: "own-item" });
-
-    await expectRedirectCall(
-      () => reservePublicWishlistItemAction(ownerFormData),
-      "/share/opaque-token?action=reserve&error=own-item",
-    );
-
-    const reservedFormData = new FormData();
-    reservedFormData.set("token", "opaque-token");
-    reservedFormData.set("itemId", "item-1");
+    const formData = new FormData();
+    formData.set("token", "opaque-token");
+    formData.set("itemId", "item-1");
     mocks.createReservation.mockResolvedValueOnce({ status: "error", code: "already-reserved" });
 
     await expectRedirectCall(
-      () => reservePublicWishlistItemAction(reservedFormData),
+      () => reservePublicWishlistItemAction(formData),
       "/share/opaque-token?action=reserve&error=already-reserved",
     );
   });


### PR DESCRIPTION
Closes #138.

The reservation logic previously blocked wishlist owners from reserving
their own items. This restriction is removed as part of M9-I3.

## What changed

**Core logic (`src/modules/reservation/server/`)**
- Removed `own-item` guard from `getItemReservationEligibility` and
  `createReservation` in `lifecycle.ts`
- Removed `"own-item"` from `ReservationEligibility` and
  `CreateReservationResult` types
- `OwnerWishlistItemReservation` is now a discriminated union with
  `isOwn: boolean` and `reservationId` when self-reserved
- `CurrentUserReservation` now includes `isOwnItem: boolean`

**Dashboard (`src/app/page.tsx`, `src/app/_dashboard/`)**
- New `ReserveItemButton` and `CancelItemReservationButton` components
- Item footer restructured into start/center/end sections so the reserve
  button is visually centered between Edit and Delete
- Self-reserved items: blue status strip, «Отменить» button, inline
  cancel action

**Share page (`src/app/share/[token]/`)**
- Reserve button now renders for owners; owner hint text updated
- Dead `case "own-item":` branches removed from actions and page

**Reservations page (`src/app/reservations/page.tsx`)**
- Self-reserved items show blue status strip and «Моё желание» badge

## How to verify

1. Register an account, add a wishlist item
2. On the dashboard, click «Забронировать» — status strip turns blue,
   button changes to «Отменить»
3. Click «Отменить» — status returns to available, button returns
4. Open your own share link — «Забронировать» button is visible and works
5. On `/reservations`, self-reserved items show blue strip + «Моё желание»

## Tests

- `reservation-lifecycle.test.ts` — removed `own-item` block, added owner
  eligibility and create tests
- `reservation-owner-wishlist.test.ts` — updated for discriminated union
  with `isOwn` and `reservationId`
- `reservation-current-user.test.ts` — added `wishlists` mock, `isOwnItem`
  assertions
- `reservations-page.test.ts` — added `isOwnItem` in mocks, badge test
- `share-page.test.ts` — owner now sees reserve button; removed `own-item`
  test case
- `owner-journey.spec.ts` — updated owner hint text, added self-reserve step

## Documentation

`CHANGELOG.md` `Unreleased` updated.