### PR TITLE
feat(wishlist): item starring — toggle, sort order, and star badge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ The format is based on Keep a Changelog, and this project follows SemVer.
 - Owners can now reserve their own wishlist items from the dashboard and
   the share page. Self-reserved items are visually distinct on the dashboard
   and the reservations page.
+- Item starring: owners can mark any item as a favourite with a star toggle.
+  Starred items sort to the top of the list on both the dashboard and the
+  public share page. Unstarred items keep their creation order below.
+  The share page shows a read-only star badge on starred items so gift-givers
+  can see priorities at a glance.
 
 ## [1.0.1] - 2026-04-23
 

--- a/docs/master-plan.md
+++ b/docs/master-plan.md
@@ -94,13 +94,13 @@ Status:
 
 Execution backlog:
 1. Self-reservation — remove owner-check from reservation logic
-2. Item prioritization — schema addition, sort, and UI badge
+2. Item starring — boolean favourite toggle, sort order, and star badge
 3. Account profile «О себе» — bio field, settings page, display on share page
 4. Multiple wishlists — create/rename/switch UI, per-wishlist share links
 
 Recommended issue shape:
 - `M9-I1 Multiple wishlists — create, rename, switch UI and per-wishlist share links`
-- `M9-I2 Item prioritization — schema, sort, and priority badge`
+- `M9-I2 Item starring — boolean favourite toggle, sort order, and star badge`
 - `M9-I3 Self-reservation — remove owner restriction`
 - `M9-I4 Account profile — bio field, settings, share page display`
 
@@ -118,26 +118,26 @@ Dependencies:
 
 Scope notes:
 - Self-reservation (`M9-I3`) is a one-line logic change; keep the PR minimal.
-- Priority sort (`M9-I2`) must be consistent between the owner dashboard and the public share page.
+- Item starring (`M9-I2`) uses a boolean `starred` field (not an enum); starred items sort to the top on both the dashboard and the share page; sort must be consistent between both views.
 - Profile bio (`M9-I4`) is visible to authenticated users on the share page, not to guests. This is intentional: it helps gift-givers, not strangers.
 - Multiple wishlists (`M9-I1`): the schema already supports N wishlists per user. The effort is entirely in the UI: create/rename/switch, dashboard navigation, and wiring each wishlist to its own share link.
 - Do not add size/measurement fields to the profile in this milestone — start with bio only.
 
 Acceptance targets:
 - owner can reserve their own wishlist items
-- owner can mark items as high / medium / low priority; items sort by priority on the dashboard and share page
+- owner can mark items as starred (favourite); starred items sort to the top on the dashboard and share page
 - owner can write a short «О себе» bio in account settings; bio is shown on the share page to authenticated viewers
 - owner can create and name multiple wishlists, switch between them on the dashboard, and generate a separate share link per wishlist
 
 Exit criteria:
 - self-reservation works end-to-end without errors
-- priority enum migration applied; sort is consistent on dashboard and share page
+- starred boolean migration applied; sort is consistent on dashboard and share page
 - bio field migration applied; bio visible on share page to authenticated non-guest visitors
 - multiple wishlist create/rename/switch UI works; each wishlist has an independent share link
 
 Definition of small PRs for this milestone:
 - self-reservation PR only removes the owner-check guard and updates the related test
-- prioritization PR only adds the `priority` column migration, updates sort queries, adds the badge UI, and does not touch auth or share logic
+- starring PR only adds the `starred` boolean column migration, updates sort queries, adds the star toggle and read-only badge UI, and does not touch auth or share logic
 - profile PR only adds the `bio` column migration, adds an account settings form, and renders bio on the share page
 - multiple wishlists PR only adds wishlist create/rename/switch UI and wires share links; does not change item or reservation logic
 

--- a/drizzle/0006_quick_patch.sql
+++ b/drizzle/0006_quick_patch.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "wishlist_items" ADD COLUMN "starred" boolean DEFAULT false NOT NULL;

--- a/drizzle/0006_starred-wishlist-items.sql
+++ b/drizzle/0006_starred-wishlist-items.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "wishlist_items" ADD COLUMN "starred" boolean NOT NULL DEFAULT false;

--- a/drizzle/meta/0006_snapshot.json
+++ b/drizzle/meta/0006_snapshot.json
@@ -1,0 +1,639 @@
+{
+  "id": "2526d906-e81d-4795-8180-3408d5d7fb46",
+  "prevId": "0f0e6c1f-7607-4a20-bd4a-354af04f9ab5",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_token": {
+          "name": "session_token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_session_token_unique": {
+          "name": "sessions_session_token_unique",
+          "columns": [
+            {
+              "expression": "session_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_user_id_idx": {
+          "name": "sessions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_expires_at_idx": {
+          "name": "sessions_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reservations": {
+      "name": "reservations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "wishlist_item_id": {
+          "name": "wishlist_item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "reservations_wishlist_item_id_idx": {
+          "name": "reservations_wishlist_item_id_idx",
+          "columns": [
+            {
+              "expression": "wishlist_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reservations_user_id_idx": {
+          "name": "reservations_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reservations_wishlist_item_id_active_unique": {
+          "name": "reservations_wishlist_item_id_active_unique",
+          "columns": [
+            {
+              "expression": "wishlist_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"reservations\".\"cancelled_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reservations_wishlist_item_id_wishlist_items_id_fk": {
+          "name": "reservations_wishlist_item_id_wishlist_items_id_fk",
+          "tableFrom": "reservations",
+          "tableTo": "wishlist_items",
+          "columnsFrom": [
+            "wishlist_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reservations_user_id_users_id_fk": {
+          "name": "reservations_user_id_users_id_fk",
+          "tableFrom": "reservations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.share_links": {
+      "name": "share_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "wishlist_id": {
+          "name": "wishlist_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "share_links_token_unique": {
+          "name": "share_links_token_unique",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "share_links_wishlist_id_idx": {
+          "name": "share_links_wishlist_id_idx",
+          "columns": [
+            {
+              "expression": "wishlist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "share_links_wishlist_id_active_unique": {
+          "name": "share_links_wishlist_id_active_unique",
+          "columns": [
+            {
+              "expression": "wishlist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"share_links\".\"is_active\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "share_links_wishlist_id_wishlists_id_fk": {
+          "name": "share_links_wishlist_id_wishlists_id_fk",
+          "tableFrom": "share_links",
+          "tableTo": "wishlists",
+          "columnsFrom": [
+            "wishlist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wishlist_items": {
+      "name": "wishlist_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "wishlist_id": {
+          "name": "wishlist_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(12, 0)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "starred": {
+          "name": "starred",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "wishlist_items_wishlist_id_idx": {
+          "name": "wishlist_items_wishlist_id_idx",
+          "columns": [
+            {
+              "expression": "wishlist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wishlist_items_wishlist_id_created_at_idx": {
+          "name": "wishlist_items_wishlist_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "wishlist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wishlist_items_wishlist_id_wishlists_id_fk": {
+          "name": "wishlist_items_wishlist_id_wishlists_id_fk",
+          "tableFrom": "wishlist_items",
+          "tableTo": "wishlists",
+          "columnsFrom": [
+            "wishlist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wishlists": {
+      "name": "wishlists",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "wishlists_user_id_idx": {
+          "name": "wishlists_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wishlists_user_id_is_active_idx": {
+          "name": "wishlists_user_id_is_active_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wishlists_user_id_users_id_fk": {
+          "name": "wishlists_user_id_users_id_fk",
+          "tableFrom": "wishlists",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1776235906196,
       "tag": "0005_lonely_zzzax",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1777033112363,
+      "tag": "0006_quick_patch",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/_dashboard/item-actions.ts
+++ b/src/app/_dashboard/item-actions.ts
@@ -2,7 +2,10 @@
 
 import { requireCurrentUser } from "@/modules/auth/server/current-user";
 import { createCurrentWishlistItem } from "@/modules/wishlist/server/create-item";
-import { updateCurrentWishlistItem } from "@/modules/wishlist/server/manage-item";
+import {
+  toggleCurrentWishlistItemStarred,
+  updateCurrentWishlistItem,
+} from "@/modules/wishlist/server/manage-item";
 
 export type ItemValues = {
   title: string;
@@ -35,6 +38,11 @@ export type CancelItemReservationState = {
 
 export type RegenerateState = {
   status: "success" | "error";
+} | null;
+
+export type ToggleStarredState = {
+  status: "success" | "error";
+  starred?: boolean;
 } | null;
 
 export async function createItemAction(
@@ -77,6 +85,21 @@ export async function updateItemAction(
   }
 
   return { status: "error", error: result.code, key: (prev?.key ?? 0) + 1, values };
+}
+
+export async function toggleStarredAction(
+  _prev: ToggleStarredState,
+  formData: FormData,
+): Promise<ToggleStarredState> {
+  const user = await requireCurrentUser();
+  const itemId = getString(formData, "itemId");
+  const result = await toggleCurrentWishlistItemStarred(user.id, itemId);
+
+  if (result.status === "success") {
+    return { status: "success", starred: result.starred };
+  }
+
+  return { status: "error" };
 }
 
 function getString(formData: FormData, name: string): string {

--- a/src/app/_dashboard/star-item-button.tsx
+++ b/src/app/_dashboard/star-item-button.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { useActionState, useOptimistic, useTransition, useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { type ToggleStarredState, toggleStarredAction } from "@/app/_dashboard/item-actions";
+
+function StarIcon({ filled }: { filled: boolean }) {
+  return (
+    <svg
+      width="18"
+      height="18"
+      viewBox="0 0 24 24"
+      fill={filled ? "currentColor" : "none"}
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2" />
+    </svg>
+  );
+}
+
+type StarButtonProps = {
+  itemId: string;
+  starred: boolean;
+  starLabel: string;
+  unstarLabel: string;
+};
+
+export function StarButton({ itemId, starred, starLabel, unstarLabel }: StarButtonProps) {
+  const router = useRouter();
+  const [, startTransition] = useTransition();
+  const [state, formAction] = useActionState<ToggleStarredState, FormData>(toggleStarredAction, null);
+  const [optimisticStarred, setOptimisticStarred] = useOptimistic(starred);
+
+  useEffect(() => {
+    if (state?.status === "success") {
+      startTransition(() => router.refresh());
+    }
+  }, [state]);
+
+  function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    const formData = new FormData(e.currentTarget);
+    startTransition(() => {
+      setOptimisticStarred((prev) => !prev);
+      formAction(formData);
+    });
+  }
+
+  return (
+    <form onSubmit={handleSubmit} style={{ display: "contents" }}>
+      <input type="hidden" name="itemId" value={itemId} />
+      <button
+        type="submit"
+        className={`item-star-btn${optimisticStarred ? " item-star-btn--starred" : ""}`}
+        aria-label={optimisticStarred ? unstarLabel : starLabel}
+        aria-pressed={optimisticStarred}
+      >
+        <StarIcon filled={optimisticStarred} />
+      </button>
+    </form>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,6 +8,7 @@ import {
   regenerateCurrentShareLink,
 } from "@/modules/share";
 import type { DeleteItemState, RegenerateState, ReserveItemState, CancelItemReservationState } from "./_dashboard/item-actions";
+import { StarButton } from "./_dashboard/star-item-button";
 import { getCurrentOwnerWishlistWithReservations, createReservation, cancelReservation } from "@/modules/reservation";
 import { deleteCurrentWishlistItem } from "@/modules/wishlist/server/manage-item";
 import { OpenFormButton, AddItemFormFocus } from "./_dashboard/open-form-button";
@@ -268,6 +269,14 @@ async function DashboardView({ userId }: { userId: string }) {
                           ) : null}
                         </div>
                       ) : null}
+                    </div>
+                    <div className="item-card-top-right">
+                      <StarButton
+                        itemId={item.id}
+                        starred={item.starred}
+                        starLabel={messages.dashboard.starLabel}
+                        unstarLabel={messages.dashboard.unstarLabel}
+                      />
                     </div>
                   </div>
                 </div>

--- a/src/app/share/[token]/page.tsx
+++ b/src/app/share/[token]/page.tsx
@@ -27,6 +27,7 @@ type WishlistView = {
     url: string | null;
     note: string | null;
     price: string | null;
+    starred: boolean;
     reservation: { status: "available" | "reserved" };
   }>;
 };
@@ -41,6 +42,7 @@ const DEV_MOCK_WISHLIST: WishlistView = {
       url: "https://example.com/sony-headphones",
       note: "Чёрного цвета, если есть возможность",
       price: "29 990 ₽",
+      starred: true,
       reservation: { status: "available" },
     },
     {
@@ -49,6 +51,7 @@ const DEV_MOCK_WISHLIST: WishlistView = {
       url: null,
       note: null,
       price: "850 ₽",
+      starred: false,
       reservation: { status: "reserved" },
     },
     {
@@ -57,6 +60,7 @@ const DEV_MOCK_WISHLIST: WishlistView = {
       url: "https://example.com/ozon-gift",
       note: "На любую сумму",
       price: null,
+      starred: false,
       reservation: { status: "available" },
     },
   ],
@@ -259,11 +263,22 @@ function SharePageView({
               <li key={item.id} className="share-item-card" data-testid="share-item-card">
                 <div className="share-item-header">
                   <h3 className="share-item-title">{item.title}</h3>
-                  {item.reservation.status === "reserved" ? (
-                    <span className="ui-badge ui-badge-reserved">
-                      {messages.share.reservedLabel}
-                    </span>
-                  ) : null}
+                  <div className="share-item-header-right">
+                    {item.starred ? (
+                      <span className="share-item-star" aria-label={messages.share.starredLabel}>
+                        <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"
+                          stroke="currentColor" strokeWidth="2" strokeLinecap="round"
+                          strokeLinejoin="round" aria-hidden="true">
+                          <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2" />
+                        </svg>
+                      </span>
+                    ) : null}
+                    {item.reservation.status === "reserved" ? (
+                      <span className="ui-badge ui-badge-reserved">
+                        {messages.share.reservedLabel}
+                      </span>
+                    ) : null}
+                  </div>
                 </div>
                 {item.price || item.url || item.note ? (
                   <div className="share-item-meta">

--- a/src/app/styles/base.css
+++ b/src/app/styles/base.css
@@ -17,6 +17,8 @@
   --color-accent-surface: #eff6ff;
   --color-status-available: #16a34a;
   --color-status-reserved: #7c3aed;
+  --color-star: #f59e0b;
+  --color-star-hover: #d97706;
   --color-dev-surface: #fffbeb;
   --color-dev-border: #fde68a;
 

--- a/src/app/styles/dashboard.css
+++ b/src/app/styles/dashboard.css
@@ -176,6 +176,42 @@
     }
   }
 
+  /* ── Star button ─────────────────────────────────────── */
+  .item-card-top-right {
+    flex-shrink: 0;
+    display: flex;
+    align-items: flex-start;
+  }
+
+  .item-star-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 2.25rem;
+    height: 2.25rem;
+    border: none;
+    border-radius: var(--radius-sm);
+    background: transparent;
+    color: var(--color-text-muted);
+    cursor: pointer;
+    padding: 0;
+    transition: color 120ms ease, background-color 120ms ease;
+  }
+
+  .item-star-btn:hover {
+    color: var(--color-star);
+    background: #fef3c7;
+  }
+
+  .item-star-btn--starred {
+    color: var(--color-star);
+  }
+
+  .item-star-btn--starred:hover {
+    color: var(--color-star-hover);
+    background: #fef3c7;
+  }
+
   /* ── Add item collapsible ────────────────────────────── */
   .add-item-details {
     scroll-margin-top: 80px;

--- a/src/app/styles/share.css
+++ b/src/app/styles/share.css
@@ -107,6 +107,19 @@
     gap: var(--space-3);
   }
 
+  .share-item-header-right {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    flex-shrink: 0;
+  }
+
+  .share-item-star {
+    display: inline-flex;
+    align-items: center;
+    color: var(--color-star);
+  }
+
   .share-item-title {
     font-size: 1rem;
     font-weight: 700;

--- a/src/modules/i18n/dictionaries/ru/app.ts
+++ b/src/modules/i18n/dictionaries/ru/app.ts
@@ -164,6 +164,8 @@ export const app = {
     deleteConfirmLabel: "Да, удалить",
     deleteCancelLabel: "Отмена",
     editToggleLabel: "Редактировать",
+    starLabel: "Добавить в избранное",
+    unstarLabel: "Убрать из избранного",
     reserveLabel: "Забронировать",
     cancelReservationLabel: "Отменить",
     summaryLabel: "Текущий вишлист",
@@ -257,6 +259,7 @@ export const app = {
     ownerHint: "Это ваш вишлист. Здесь можно проверить, как он выглядит, и забронировать желания, которые уже исполнены.",
     reserveLabel: "Забронировать",
     reservedLabel: "Уже забронировано",
+    starredLabel: "Избранное",
     successMessage: "Желание забронировано.",
     errors: {
       alreadyReserved: "Это желание уже забронировано. Обновите страницу или выберите другой подарок.",

--- a/src/modules/wishlist/db/schema.ts
+++ b/src/modules/wishlist/db/schema.ts
@@ -33,6 +33,7 @@ export const wishlistItems = pgTable(
     url: varchar("url", { length: 2048 }),
     note: text("note"),
     price: numeric("price", { precision: 12, scale: 0 }),
+    starred: boolean("starred").notNull().default(false),
     createdAt: timestamp("created_at", { withTimezone: true })
       .defaultNow()
       .notNull(),

--- a/src/modules/wishlist/server/items.ts
+++ b/src/modules/wishlist/server/items.ts
@@ -1,4 +1,4 @@
-import { asc, eq } from "drizzle-orm";
+import { asc, desc, eq } from "drizzle-orm";
 import { wishlistItems, wishlists } from "@/modules/wishlist/db/schema";
 import {
   type CurrentWishlist,
@@ -12,6 +12,7 @@ export type WishlistItemRecord = {
   url: string | null;
   note: string | null;
   price: string | null;
+  starred: boolean;
   createdAt: Date;
   updatedAt: Date;
 };
@@ -31,11 +32,12 @@ export async function listWishlistItems(wishlistId: string): Promise<WishlistIte
       url: true,
       note: true,
       price: true,
+      starred: true,
       createdAt: true,
       updatedAt: true,
     },
     where: eq(wishlistItems.wishlistId, wishlistId),
-    orderBy: [asc(wishlistItems.createdAt), asc(wishlistItems.id)],
+    orderBy: [desc(wishlistItems.starred), asc(wishlistItems.createdAt), asc(wishlistItems.id)],
   });
 }
 

--- a/src/modules/wishlist/server/manage-item.ts
+++ b/src/modules/wishlist/server/manage-item.ts
@@ -15,6 +15,10 @@ export type DeleteWishlistItemResult =
   | { status: "success" }
   | { status: "error"; code: "item-not-found" | "unknown" };
 
+export type ToggleStarredResult =
+  | { status: "success"; starred: boolean }
+  | { status: "error"; code: "item-not-found" | "unknown" };
+
 export async function updateCurrentWishlistItem(
   userId: string,
   itemId: string,
@@ -75,6 +79,41 @@ export async function deleteCurrentWishlistItem(
     }
 
     return { status: "success" };
+  } catch {
+    return { status: "error", code: "unknown" };
+  }
+}
+
+export async function toggleCurrentWishlistItemStarred(
+  userId: string,
+  itemId: string,
+): Promise<ToggleStarredResult> {
+  try {
+    const wishlist = await getCurrentWishlist(userId);
+
+    if (!wishlist) {
+      return { status: "error", code: "item-not-found" };
+    }
+
+    const db = await getDb();
+
+    const existing = await db.query.wishlistItems.findFirst({
+      columns: { id: true, starred: true },
+      where: and(eq(wishlistItems.id, itemId), eq(wishlistItems.wishlistId, wishlist.id)),
+    });
+
+    if (!existing) {
+      return { status: "error", code: "item-not-found" };
+    }
+
+    const newStarred = !existing.starred;
+
+    await db
+      .update(wishlistItems)
+      .set({ starred: newStarred, updatedAt: new Date() })
+      .where(and(eq(wishlistItems.id, itemId), eq(wishlistItems.wishlistId, wishlist.id)));
+
+    return { status: "success", starred: newStarred };
   } catch {
     return { status: "error", code: "unknown" };
   }

--- a/tests/e2e/owner-journey.spec.ts
+++ b/tests/e2e/owner-journey.spec.ts
@@ -85,6 +85,36 @@ test("owner can complete the core wishlist journey end to end", async ({ page })
     await expect(updatedItemCard).toContainText("2\u00a0490");
   });
 
+  await test.step("owner can star and unstar a wishlist item", async () => {
+    const itemCard = getWishlistItemCard(page, updatedItem.title);
+    const starBtn = itemCard.getByRole("button", { name: "Добавить в избранное" });
+
+    await expect(starBtn).toBeVisible();
+    await expect(starBtn).toHaveAttribute("aria-pressed", "false");
+
+    await starBtn.click();
+
+    await expect(itemCard.getByRole("button", { name: "Убрать из избранного" })).toBeVisible();
+    await expect(itemCard.getByRole("button", { name: "Убрать из избранного" })).toHaveAttribute("aria-pressed", "true");
+
+    // Share page shows a read-only star for starred items
+    const shareUrl = await page.getByTestId("share-link-url").inputValue();
+    const sharePreviewPage = await page.context().newPage();
+
+    await sharePreviewPage.goto(shareUrl);
+
+    const shareItemCard = sharePreviewPage.getByTestId("share-item-card").filter({
+      has: sharePreviewPage.getByRole("heading", { name: updatedItem.title, exact: true }),
+    });
+
+    await expect(shareItemCard.locator(".share-item-star")).toBeVisible();
+    await sharePreviewPage.close();
+
+    // Unstar to restore neutral state
+    await itemCard.getByRole("button", { name: "Убрать из избранного" }).click();
+    await expect(itemCard.getByRole("button", { name: "Добавить в избранное" })).toBeVisible();
+  });
+
   await test.step("regenerate the share link and verify the old one is invalid", async () => {
     await expect(page.getByTestId("share-link-url")).toHaveValue(/\/share\//);
 


### PR DESCRIPTION
Closes #140.

Owners can star any wishlist item; starred items sort to the top on
the dashboard and the public share page.

## What changed

- Added starred boolean column to wishlist_items via migration 0006
- listWishlistItems now orders by starred DESC, created_at ASC
- toggleCurrentWishlistItemStarred server action with owner check
- StarButton client component with optimistic toggle and router.refresh
- Read-only star badge on share page for starred items
- --color-star / --color-star-hover tokens; 2.25 rem touch target
- i18n keys: starLabel, unstarLabel, starredLabel

## How to verify

- Add two items on the dashboard; both appear unstarred (dim ☆)
- Click the star on one item — it turns amber (★) and moves to top
- Reload — starred state persists
- Open the public share link — starred item is first with amber ★
- Click the star again — item returns to normal order

## Tests

- Added "owner can star and unstar a wishlist item" step to
  tests/e2e/owner-journey.spec.ts
- Covers toggle aria-pressed state, share page badge, unstar restore

## Documentation

- CHANGELOG.md Unreleased section updated
- docs/master-plan.md M9-I2 updated to reflect boolean starring