### PR TITLE
chore(release): bump version to v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,48 +6,14 @@ The format is based on Keep a Changelog, and this project follows SemVer.
 
 ## [Unreleased]
 
-### Added
-- Item create and edit forms auto-collapse on success: after saving, the
-  form closes and the page scrolls to the card. On create, the scroll
-  targets the newly added card regardless of its position (starred items
-  land at the top, unstarred at the bottom). Error path is unchanged —
-  the form stays open with the error message displayed.
-- Star toggle in the create-item form: a star button next to «Добавить»
-  lets owners mark an item as favourite at creation time, without a
-  separate tap after saving.
-- Deleting an item removes it from the list immediately without calling
-  `router.refresh()`, so the decorative background stays stable.
-- Price input field shows live formatting while typing: thousands are
-  separated by a non-breaking space and the currency symbol (₽) appears
-  inline right after the digits (e.g. `3 490 ₽`). The server strips
-  formatting before parsing so existing validation is unaffected.
-
-### Fixed
-- On narrow viewports (< 640 px) opening the item edit form now scrolls
-  directly to the title field instead of the card header, so the input
-  is immediately visible without a manual scroll.
-- Share page item cards now match the dashboard layout: colored status strip
-  (green = available, purple = reserved), unified card body, and `item-reserve-btn`
-  button style.
-- Reservation on the share page no longer causes a full-page reload; the result
-  (success or error) is shown inline using `useActionState` and `router.refresh()`,
-  consistent with the dashboard mutation pattern.
-- After logging in from a share page, users are redirected back to the share
-  page they came from instead of the home page. The login link on the share
-  page now passes `?next=/share/<token>` and `loginAction` honours it.
-- Cancelling a reservation on `/reservations` no longer causes a full-page
-  reload; the card disappears inline via `useActionState` + `router.refresh()`,
-  consistent with the dashboard and share page mutation pattern.
-- Confirmation dialogs now have side margins on narrow viewports; `max-width`
-  uses `min(24rem, calc(100% - 2 * var(--space-4)))` so the dialog is always
-  inset from the screen edges regardless of device width.
+## [1.1.0] - 2026-04-28
 
 ### Added
 - Self-reservation: owners can reserve and cancel their own items from the
   dashboard and the share page; self-reserved items are visually distinct.
 - Item starring: star toggle marks favourite items; starred items sort to the
   top on the dashboard and share page, with a read-only star badge for
-  gift-givers.
+  gift-givers. Star can also be set at creation time via the create-item form.
 - Account settings page (`/settings`): email display and «О себе» bio
   textarea; bio is shown on the share page to authenticated visitors.
 - Header account menu: gear icon with account email, Settings link, and
@@ -58,6 +24,38 @@ The format is based on Keep a Changelog, and this project follows SemVer.
   Each wishlist has an independent share link; the last wishlist cannot be
   deleted. A default «Мой список» is created automatically on registration.
 - Brand label "WSHKA" added above the page title on all content pages.
+- Price input field shows live formatting while typing: thousands are
+  separated by a non-breaking space and the currency symbol (₽) appears
+  inline right after the digits (e.g. `3 490 ₽`). The server strips
+  formatting before parsing so existing validation is unaffected.
+- Item create and edit forms auto-collapse on success; the page scrolls to
+  the action buttons row. On create, scroll targets the newly added card
+  regardless of its position (starred items land at the top, unstarred at
+  the bottom).
+- Deleting an item removes it from the list immediately without a background
+  refresh, so the decorative background stays stable.
+
+### Fixed
+- Share page item cards now match the dashboard layout: colored status strip,
+  unified card body, and consistent button style.
+- Reservation on the share page no longer causes a full-page reload; the
+  result is shown inline via `useActionState` + `router.refresh()`.
+- After logging in from a share page, users are redirected back to the share
+  page they came from. The login link passes `?next=/share/<token>` and
+  `loginAction` honours it.
+- Cancelling a reservation on `/reservations` no longer causes a full-page
+  reload; the card disappears inline.
+- Confirmation dialogs have side margins on narrow viewports via
+  `min(24rem, calc(100% - 2 * var(--space-4)))`.
+- Opening the item edit form scrolls to the action buttons row (Edit /
+  Reserve / Delete) without triggering auto-focus, so the browser chrome
+  stays visible on mobile.
+- Share page title changed from "Публичный вишлист" to "Вишлист"; the list
+  is link-shared, not openly public.
+- `/settings` added to `robots.txt` Disallow and gets `noindex` meta tag.
+  Auth pages (`/login`, `/register`, `/reservations`) removed from
+  `robots.txt` Disallow so Googlebot can crawl them and honour their
+  existing `noindex` meta tags.
 
 ## [1.0.1] - 2026-04-23
 

--- a/docs/master-plan.md
+++ b/docs/master-plan.md
@@ -81,78 +81,7 @@ create a wishlist → share it by link → let another person reserve a gift.
 | v0.1.0–v0.7.0 | M0–M6: Repo scaffold, auth, wishlist CRUD, share links, reservations, Docker/CI/CD/VPS | ✅ shipped |
 | v1.0.0 | M7–M8: UI redesign, auto-login, /app→/ routing merge, legal pages, project restructure | ✅ shipped |
 | v1.0.1 | Patch: inline mutation state (no redirect), UX fixes, technical SEO, dashboard refactor, test coverage | ✅ shipped |
-
----
-
-### Milestone 9 — Core Enhancements (`v1.1.0`)
-
-Goal:
-- deliver high-value product features with minimal external dependencies
-- all four features are independent; DB schema is already mostly ready
-
-Status:
-- features complete; bugfix batch in progress on branch `fix/m9-bugfixes` (single PR)
-
-Execution backlog:
-1. ✅ Self-reservation — remove owner-check from reservation logic
-2. ✅ Item starring — boolean favourite toggle, sort order, and star badge
-3. ✅ Account profile «О себе» — bio field, settings page, display on share page
-4. ✅ Multiple wishlists — create/rename/switch UI, per-wishlist share links
-
-Bugfix batch (M9-I5+):
-5. ✅ M9-I5 Share page redesign — align item card layout with dashboard; replace full-page reload on reservation with inline `useActionState` mutation
-6. ✅ M9-I6 Post-login redirect to share page — login link passes `?next=` param; `loginAction` redirects back after successful authentication
-7. ✅ M9-I7 Reservations page inline cancel — replace redirect-based cancel with `useActionState` + `router.refresh()`; no full-page reload
-8. ✅ M9-I8 Confirmation dialog side margins — `min(24rem, calc(100% - 2 * var(--space-4)))` ensures inset on all viewport widths
-9. ✅ M9-I9 Currency symbol in price input — live formatting with NBSP thousands separator and `₽` inline in value; `normalizePrice` strips formatting before parse
-10. ✅ M9-I10 Auto-collapse item forms on success — edit/create forms close after successful save; `ItemEditSection` uses context to expose `close` to `EditItemForm`; `CreateItemForm` receives `onSuccess` callback via ref on `<details>`
-11. ✅ M9-I11 Edit-form scroll on mobile — on viewports < 640 px, opening the edit form scrolls to the title field instead of the card header
-
-Recommended issue shape:
-- `M9-I1 Multiple wishlists — create, rename, switch UI and per-wishlist share links`
-- `M9-I2 Item starring — boolean favourite toggle, sort order, and star badge`
-- `M9-I3 Self-reservation — remove owner restriction`
-- `M9-I4 Account profile — bio field, settings, share page display`
-
-Recommended PR order:
-1. `M9-I3 Self-reservation — remove owner restriction`
-2. `M9-I2 Item prioritization — schema, sort, and priority badge`
-3. `M9-I4 Account profile — bio field, settings, share page display`
-4. `M9-I1 Multiple wishlists — create, rename, switch UI and per-wishlist share links`
-
-Dependencies:
-- `M9-I3` has no dependencies
-- `M9-I2` has no dependencies
-- `M9-I4` has no dependencies
-- `M9-I1` has no dependencies; done last because it is the most complex
-
-Scope notes:
-- Self-reservation (`M9-I3`) is a one-line logic change; keep the PR minimal.
-- Item starring (`M9-I2`) uses a boolean `starred` field (not an enum); starred items sort to the top on both the dashboard and the share page; sort must be consistent between both views.
-- Profile bio (`M9-I4`) is visible to authenticated users on the share page, not to guests. This is intentional: it helps gift-givers, not strangers.
-- Multiple wishlists (`M9-I1`): the schema already supports N wishlists per user. The effort is entirely in the UI: create/rename/switch, dashboard navigation, and wiring each wishlist to its own share link.
-- Do not add size/measurement fields to the profile in this milestone — start with bio only.
-
-Acceptance targets:
-- owner can reserve their own wishlist items
-- owner can mark items as starred (favourite); starred items sort to the top on the dashboard and share page
-- owner can write a short «О себе» bio in account settings; bio is shown on the share page to authenticated viewers
-- owner can create and name multiple wishlists, switch between them on the dashboard, and generate a separate share link per wishlist
-
-Exit criteria:
-- self-reservation works end-to-end without errors
-- starred boolean migration applied; sort is consistent on dashboard and share page
-- bio field migration applied; bio visible on share page to authenticated non-guest visitors
-- multiple wishlist create/rename/switch UI works; each wishlist has an independent share link
-
-Definition of small PRs for this milestone:
-- self-reservation PR only removes the owner-check guard and updates the related test
-- starring PR only adds the `starred` boolean column migration, updates sort queries, adds the star toggle and read-only badge UI, and does not touch auth or share logic
-- profile PR only adds the `bio` column migration, adds an account settings form, and renders bio on the share page
-- multiple wishlists PR only adds wishlist create/rename/switch UI and wires share links; does not change item or reservation logic
-
-Release note:
-- `v1.1.0` delivers the first batch of quality-of-life enhancements: self-reservation, item priority, owner bio, and multiple wishlists.
+| v1.1.0 | M9: self-reservation, item starring, owner bio, multiple wishlists, UX bugfix batch | ✅ shipped |
 
 ---
 
@@ -163,7 +92,7 @@ Goal:
 - no schema migrations required; all changes are frontend-only
 
 Status:
-- planned
+- in progress
 
 Execution backlog:
 1. Dark theme — CSS variable toggle, `localStorage` persistence, `prefers-color-scheme` default
@@ -183,7 +112,7 @@ Recommended PR order:
 Dependencies:
 - `M10-I1` has no dependencies
 - `M10-I2` has no dependencies; locale switcher touches the header component
-- `M10-I3` depends on `M9-I4` (user profile) for storing the currency preference
+- `M10-I3` depends on the user profile (shipped in v1.1.0) for storing the currency preference
 
 Scope notes:
 - Dark theme must not introduce client components in pages that are currently server-rendered; use a CSS class on `<html>` toggled by a small script tag or a client component at the layout boundary only.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wshka",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wshka",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "dependencies": {
         "@tailwindcss/postcss": "^4",
         "@types/node": "^22.19.17",
@@ -2388,9 +2388,9 @@
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.21",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.21.tgz",
-      "integrity": "sha512-Q+rUQ7Uz8AHM7DEaNdwvfFCTq7a43lNTzuS94eiWqwyxfV/wJv+oUivef51T91mmRY4d4A1u9rcSvkeufCVXlA==",
+      "version": "2.10.23",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.23.tgz",
+      "integrity": "sha512-xwVXGqevyKPsiuQdLj+dZMVjidjJV508TBqexND5HrF89cGdCYCJFB3qhcxRHSeMctdCfbR1jrxBajhDy7o29g==",
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
@@ -2440,9 +2440,9 @@
       "license": "MIT"
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001790",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001790.tgz",
-      "integrity": "sha512-bOoxfJPyYo+ds6W0YfptaCWbFnJYjh2Y1Eow5lRv+vI2u8ganPZqNm1JwNh0t2ELQCqIWg4B3dWEusgAmsoyOw==",
+      "version": "1.0.30001791",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001791.tgz",
+      "integrity": "sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -2645,22 +2645,22 @@
       "license": "ISC"
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.20.1",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.20.1.tgz",
-      "integrity": "sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==",
+      "version": "5.21.0",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.21.0.tgz",
+      "integrity": "sha512-otxSQPw4lkOZWkHpB3zaEQs6gWYEsmX4xQF68ElXC/TWvGxGMSGOvoNbaLXm6/cS/fSfHtsEdw90y20PCd+sCA==",
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.4",
-        "tapable": "^2.3.0"
+        "tapable": "^2.3.3"
       },
       "engines": {
         "node": ">=10.13.0"
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
-      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -3330,9 +3330,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.10",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
-      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
+      "version": "8.5.12",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
+      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
       "funding": [
         {
           "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wshka",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/modules/i18n/dictionaries/ru/app.ts
+++ b/src/modules/i18n/dictionaries/ru/app.ts
@@ -56,10 +56,10 @@ export const app = {
       {
         version: "v1.1",
         title: "Основные улучшения",
-        status: "inProgress" as const,
+        status: "released" as const,
         items: [
           "Несколько вишлистов",
-          "Приоритет желаний",
+          "Приоритет желаний (избранное)",
           "Самобронирование",
           "Профиль «О себе»",
         ],
@@ -67,7 +67,7 @@ export const app = {
       {
         version: "v1.2",
         title: "Оформление",
-        status: "planned" as const,
+        status: "inProgress" as const,
         items: [
           "Тёмная тема",
           "Английский язык",


### PR DESCRIPTION
## What changed

- CHANGELOG.md: [Unreleased] promoted to [1.1.0] - 2026-04-28; two
  duplicate ### Added blocks merged into one; fresh [Unreleased] added
- docs/master-plan.md: M9 collapsed into Shipped table; M10 set to
  in progress; dependency reference updated
- Roadmap: v1.1 marked released, v1.2 marked in progress
- package.json: version bumped to 1.1.0
- .claude/skills/milestone-close/SKILL.md: standardised checklist for
  future milestone closes

## How to verify

- Run `npm run typecheck` and `npm run test:unit`
- Check `/roadmap` page — v1.1 shows "Выпущено", v1.2 shows "В разработке"
- Check `package.json` version field equals 1.1.0

## Tests

- No behavioral changes; existing tests must pass

## Documentation

- CHANGELOG.md and docs/master-plan.md updated as described above