### PR TITLE
fix(migrations): make ADD COLUMN idempotent, remove orphan migration

### DIFF
--- a/drizzle/0006_quick_patch.sql
+++ b/drizzle/0006_quick_patch.sql
@@ -1,1 +1,1 @@
-ALTER TABLE "wishlist_items" ADD COLUMN "starred" boolean DEFAULT false NOT NULL;
+ALTER TABLE "wishlist_items" ADD COLUMN IF NOT EXISTS "starred" boolean DEFAULT false NOT NULL;

--- a/drizzle/0006_starred-wishlist-items.sql
+++ b/drizzle/0006_starred-wishlist-items.sql
@@ -1,1 +1,0 @@
-ALTER TABLE "wishlist_items" ADD COLUMN "starred" boolean NOT NULL DEFAULT false;

--- a/drizzle/0007_user-bio.sql
+++ b/drizzle/0007_user-bio.sql
@@ -1,1 +1,1 @@
-ALTER TABLE "users" ADD COLUMN "bio" varchar(500);
+ALTER TABLE "users" ADD COLUMN IF NOT EXISTS "bio" varchar(500);

--- a/drizzle/0008_regular_randall_flagg.sql
+++ b/drizzle/0008_regular_randall_flagg.sql
@@ -1,1 +1,1 @@
-ALTER TABLE "wishlists" ADD COLUMN "name" varchar(100) DEFAULT 'Мой список' NOT NULL;
+ALTER TABLE "wishlists" ADD COLUMN IF NOT EXISTS "name" varchar(100) DEFAULT 'Мой список' NOT NULL;


### PR DESCRIPTION
- Add IF NOT EXISTS to 0006, 0007, 0008 ADD COLUMN statements so the runtime migrator can bootstrap __drizzle_migrations on a DB that was set up without migration tracking
- Delete orphan 0006_starred-wishlist-items.sql (duplicate of 0006_quick_patch, not referenced in the journal)
