### PR TITLE
feat(ui): dark theme — CSS variable toggle, localStorage persistence, system preference default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on Keep a Changelog, and this project follows SemVer.
 
 ## [Unreleased]
 
+### Added
+- Dark theme: CSS custom property overrides under `.dark` class on `<html>`;
+  all design tokens and hardcoded palette values have dark equivalents.
+- Theme toggle in the account menu (gear icon dropdown): switches immediately
+  without page reload; preference persisted in `localStorage`.
+- System preference default: `prefers-color-scheme: dark` is respected on
+  first visit via an inline script in `<head>` that applies the class before
+  hydration, preventing any flash of the wrong theme.
+
 ## [1.1.0] - 2026-04-28
 
 ### Added

--- a/docs/master-plan.md
+++ b/docs/master-plan.md
@@ -88,54 +88,62 @@ create a wishlist → share it by link → let another person reserve a gift.
 ### Milestone 10 — Look & Feel (`v1.2.0`)
 
 Goal:
-- deliver dark theme, English locale, and multi-currency display
+- deliver dark theme, background parallax, English locale, and multi-currency display
 - no schema migrations required; all changes are frontend-only
 
 Status:
 - in progress
 
 Execution backlog:
-1. Dark theme — CSS variable toggle, `localStorage` persistence, `prefers-color-scheme` default
-2. English locale — `en/` i18n dictionary, locale switcher in header, browser auto-detect
-3. Multiple currencies — currency preference per user profile, locale-aware display formatting
+1. ✅ Dark theme — CSS variable toggle, `localStorage` persistence, `prefers-color-scheme` default
+2. Background parallax — subtle depth effect on the wallpaper pattern, CSS or JS-driven
+3. English locale — `en/` i18n dictionary, locale switcher in header, browser auto-detect
+4. Multiple currencies — currency preference per user profile, locale-aware display formatting
 
 Recommended issue shape:
 - `M10-I1 Dark theme — CSS variable toggle and system preference default`
-- `M10-I2 English locale — en/ dictionary, locale switcher, browser auto-detect`
-- `M10-I3 Multiple currencies — currency preference in profile, display formatting`
+- `M10-I2 Background parallax — depth effect on wallpaper pattern`
+- `M10-I3 English locale — en/ dictionary, locale switcher, browser auto-detect`
+- `M10-I4 Multiple currencies — currency preference in profile, display formatting`
 
 Recommended PR order:
 1. `M10-I1 Dark theme — CSS variable toggle and system preference default`
-2. `M10-I2 English locale — en/ dictionary, locale switcher, browser auto-detect`
-3. `M10-I3 Multiple currencies — currency preference in profile, display formatting`
+2. `M10-I2 Background parallax — depth effect on wallpaper pattern`
+3. `M10-I3 English locale — en/ dictionary, locale switcher, browser auto-detect`
+4. `M10-I4 Multiple currencies — currency preference in profile, display formatting`
 
 Dependencies:
 - `M10-I1` has no dependencies
-- `M10-I2` has no dependencies; locale switcher touches the header component
-- `M10-I3` depends on the user profile (shipped in v1.1.0) for storing the currency preference
+- `M10-I2` has no dependencies
+- `M10-I3` has no dependencies; locale switcher touches the header component
+- `M10-I4` depends on the user profile (shipped in v1.1.0) for storing the currency preference
 
 Scope notes:
-- Dark theme must not introduce client components in pages that are currently server-rendered; use a CSS class on `<html>` toggled by a small script tag or a client component at the layout boundary only.
+- Dark theme must not introduce client components in pages that are currently server-rendered; use a CSS class on `<html>` toggled by a small script tag or a client component at the layout boundary only. The theme toggle is placed inside the gear-icon dropdown in `NavLinks` (already a client component); no new client boundary is introduced.
+- Background parallax must be lightweight — prefer CSS `background-attachment: fixed` or a minimal scroll listener; must not degrade performance on mobile; must work in both light and dark themes.
 - English locale duplicates the Russian dictionary in `en/`; no machine translation, write natural English.
 - Multiple currencies is display-only — no conversion rates, no external API. The preference is stored on the user profile and applied to all price formatting.
 
 Acceptance targets:
 - dark theme can be toggled manually; preference persists across sessions; `prefers-color-scheme: dark` is respected on first visit
+- background wallpaper has a visible but subtle parallax depth effect on scroll; no jank on mobile
 - all user-visible strings are available in English; switching locale changes the entire UI immediately
 - owner can set a preferred currency (e.g. ₽, $, €); all prices display in that currency with correct locale formatting
 
 Exit criteria:
 - dark/light toggle works in all routes with no flash on load
+- parallax effect is smooth on desktop; gracefully disabled or static on mobile if needed
 - English locale covers 100% of i18n keys with no missing-key fallbacks
 - currency preference is stored and applied consistently on dashboard, share page, and reservations page
 
 Definition of small PRs for this milestone:
 - dark theme PR only touches CSS variables, the theme toggle component, and layout wiring
+- parallax PR only touches background rendering; does not touch theme logic or i18n
 - locale PR only adds the `en/` dictionary, the switcher UI, and locale resolution logic; does not touch styles
 - currency PR only adds the preference field, the settings UI, and the price formatting utility; does not touch locale logic
 
 Release note:
-- `v1.2.0` delivers dark theme, English language support, and multi-currency price display.
+- `v1.2.0` delivers dark theme, background parallax, English language support, and multi-currency price display.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1050,6 +1050,9 @@
       "cpu": [
         "arm"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1065,6 +1068,9 @@
       "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1082,6 +1088,9 @@
       "cpu": [
         "ppc64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1097,6 +1106,9 @@
       "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
       "cpu": [
         "riscv64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1114,6 +1126,9 @@
       "cpu": [
         "s390x"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1129,6 +1144,9 @@
       "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1146,6 +1164,9 @@
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "musl"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1162,6 +1183,9 @@
       "cpu": [
         "x64"
       ],
+      "libc": [
+        "musl"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1177,6 +1201,9 @@
       "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
       "cpu": [
         "arm"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1200,6 +1227,9 @@
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1221,6 +1251,9 @@
       "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
       "cpu": [
         "ppc64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1244,6 +1277,9 @@
       "cpu": [
         "riscv64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1265,6 +1301,9 @@
       "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
       "cpu": [
         "s390x"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1288,6 +1327,9 @@
       "cpu": [
         "x64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1310,6 +1352,9 @@
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "musl"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1331,6 +1376,9 @@
       "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1531,6 +1579,9 @@
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1546,6 +1597,9 @@
       "integrity": "sha512-RwSHKMQ7InLy5GfkY2/n5PcFycKA08qI1VST78n09nN36nUPqCvGSMiLXlfUmzmpQpF6XeBYP2KRWHi0UW3uNg==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1563,6 +1617,9 @@
       "cpu": [
         "x64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1578,6 +1635,9 @@
       "integrity": "sha512-eAgl9NKQ84/sww0v81DQINl/vL2IBxD7sMybd0cWRw6wqgouVI53brVRBrggqBRP/NWeIAE1dm5cbKYoiMlqDQ==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1739,6 +1799,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1756,6 +1819,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1773,6 +1839,9 @@
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1790,6 +1859,9 @@
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1807,6 +1879,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1824,6 +1899,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2051,6 +2129,9 @@
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2066,6 +2147,9 @@
       "integrity": "sha512-bBADEGAbo4ASnppIziaQJelekCxdMaxisrk+fB7Thit72IBnALp9K6ffA2G4ruj90G9XRS2VQ6q2bCKbfFV82g==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2083,6 +2167,9 @@
       "cpu": [
         "x64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2098,6 +2185,9 @@
       "integrity": "sha512-2wwJRF7nyhOR0hhHoChc04xngV3iS+akccHTGtz965FwF0up4b2lOdo6kI1EbDaEXKgvcrFBYcYQQ/rrnWFVfA==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2388,9 +2478,9 @@
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.23",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.23.tgz",
-      "integrity": "sha512-xwVXGqevyKPsiuQdLj+dZMVjidjJV508TBqexND5HrF89cGdCYCJFB3qhcxRHSeMctdCfbR1jrxBajhDy7o29g==",
+      "version": "2.10.24",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.24.tgz",
+      "integrity": "sha512-I2NkZOOrj2XuguvWCK6OVh9GavsNjZjK908Rq3mIBK25+GD8vPX5w2WdxVqnQ7xx3SrZJiCiZFu+/Oz50oSYSA==",
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
@@ -2770,7 +2860,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -2945,6 +3034,9 @@
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2964,6 +3056,9 @@
       "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -2985,6 +3080,9 @@
       "cpu": [
         "x64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3004,6 +3102,9 @@
       "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -4348,13 +4449,11 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
+      "extraneous": true,
       "license": "MIT",
-      "optional": true,
       "os": [
         "aix"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4366,13 +4465,11 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
+      "extraneous": true,
       "license": "MIT",
-      "optional": true,
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4384,13 +4481,11 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
+      "extraneous": true,
       "license": "MIT",
-      "optional": true,
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4402,13 +4497,11 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
+      "extraneous": true,
       "license": "MIT",
-      "optional": true,
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4420,13 +4513,11 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
+      "extraneous": true,
       "license": "MIT",
-      "optional": true,
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4438,13 +4529,11 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
+      "extraneous": true,
       "license": "MIT",
-      "optional": true,
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4456,13 +4545,11 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
+      "extraneous": true,
       "license": "MIT",
-      "optional": true,
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4474,13 +4561,11 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
+      "extraneous": true,
       "license": "MIT",
-      "optional": true,
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4492,13 +4577,11 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
+      "extraneous": true,
       "license": "MIT",
-      "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4510,13 +4593,11 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
+      "extraneous": true,
       "license": "MIT",
-      "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4528,13 +4609,11 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
+      "extraneous": true,
       "license": "MIT",
-      "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4546,13 +4625,11 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
+      "extraneous": true,
       "license": "MIT",
-      "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4564,13 +4641,11 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
+      "extraneous": true,
       "license": "MIT",
-      "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4582,13 +4657,11 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
+      "extraneous": true,
       "license": "MIT",
-      "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4600,13 +4673,11 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
+      "extraneous": true,
       "license": "MIT",
-      "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4618,13 +4689,11 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
+      "extraneous": true,
       "license": "MIT",
-      "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4636,13 +4705,11 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
+      "extraneous": true,
       "license": "MIT",
-      "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4654,13 +4721,11 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
+      "extraneous": true,
       "license": "MIT",
-      "optional": true,
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4672,13 +4737,11 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
+      "extraneous": true,
       "license": "MIT",
-      "optional": true,
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4690,13 +4753,11 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
+      "extraneous": true,
       "license": "MIT",
-      "optional": true,
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4708,13 +4769,11 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
+      "extraneous": true,
       "license": "MIT",
-      "optional": true,
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4726,13 +4785,11 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
+      "extraneous": true,
       "license": "MIT",
-      "optional": true,
       "os": [
         "openharmony"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4744,13 +4801,11 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
+      "extraneous": true,
       "license": "MIT",
-      "optional": true,
       "os": [
         "sunos"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4762,13 +4817,11 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
+      "extraneous": true,
       "license": "MIT",
-      "optional": true,
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4780,13 +4833,11 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
+      "extraneous": true,
       "license": "MIT",
-      "optional": true,
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4798,13 +4849,11 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
+      "extraneous": true,
       "license": "MIT",
-      "optional": true,
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4840,11 +4889,9 @@
       "version": "0.28.0",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
       "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
-      "dev": true,
+      "extraneous": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1050,9 +1050,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1068,9 +1065,6 @@
       "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1088,9 +1082,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1106,9 +1097,6 @@
       "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1126,9 +1114,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1144,9 +1129,6 @@
       "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1164,9 +1146,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1183,9 +1162,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1201,9 +1177,6 @@
       "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1227,9 +1200,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1251,9 +1221,6 @@
       "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1277,9 +1244,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1301,9 +1265,6 @@
       "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1327,9 +1288,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1352,9 +1310,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1376,9 +1331,6 @@
       "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1579,9 +1531,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1597,9 +1546,6 @@
       "integrity": "sha512-RwSHKMQ7InLy5GfkY2/n5PcFycKA08qI1VST78n09nN36nUPqCvGSMiLXlfUmzmpQpF6XeBYP2KRWHi0UW3uNg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1617,9 +1563,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1635,9 +1578,6 @@
       "integrity": "sha512-eAgl9NKQ84/sww0v81DQINl/vL2IBxD7sMybd0cWRw6wqgouVI53brVRBrggqBRP/NWeIAE1dm5cbKYoiMlqDQ==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1799,9 +1739,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1819,9 +1756,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1839,9 +1773,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1859,9 +1790,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1879,9 +1807,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1899,9 +1824,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2129,9 +2051,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2147,9 +2066,6 @@
       "integrity": "sha512-bBADEGAbo4ASnppIziaQJelekCxdMaxisrk+fB7Thit72IBnALp9K6ffA2G4ruj90G9XRS2VQ6q2bCKbfFV82g==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2167,9 +2083,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2185,9 +2098,6 @@
       "integrity": "sha512-2wwJRF7nyhOR0hhHoChc04xngV3iS+akccHTGtz965FwF0up4b2lOdo6kI1EbDaEXKgvcrFBYcYQQ/rrnWFVfA==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2860,6 +2770,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -3034,9 +2945,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3056,9 +2964,6 @@
       "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -3080,9 +2985,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3102,9 +3004,6 @@
       "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -4449,11 +4348,13 @@
       "cpu": [
         "ppc64"
       ],
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "os": [
         "aix"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4465,11 +4366,13 @@
       "cpu": [
         "arm"
       ],
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4481,11 +4384,13 @@
       "cpu": [
         "arm64"
       ],
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4497,11 +4402,13 @@
       "cpu": [
         "x64"
       ],
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4513,11 +4420,13 @@
       "cpu": [
         "arm64"
       ],
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4529,11 +4438,13 @@
       "cpu": [
         "x64"
       ],
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4545,11 +4456,13 @@
       "cpu": [
         "arm64"
       ],
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4561,11 +4474,13 @@
       "cpu": [
         "x64"
       ],
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4577,11 +4492,13 @@
       "cpu": [
         "arm"
       ],
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4593,11 +4510,13 @@
       "cpu": [
         "arm64"
       ],
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4609,11 +4528,13 @@
       "cpu": [
         "ia32"
       ],
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4625,11 +4546,13 @@
       "cpu": [
         "loong64"
       ],
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4641,11 +4564,13 @@
       "cpu": [
         "mips64el"
       ],
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4657,11 +4582,13 @@
       "cpu": [
         "ppc64"
       ],
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4673,11 +4600,13 @@
       "cpu": [
         "riscv64"
       ],
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4689,11 +4618,13 @@
       "cpu": [
         "s390x"
       ],
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4705,11 +4636,13 @@
       "cpu": [
         "x64"
       ],
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4721,11 +4654,13 @@
       "cpu": [
         "arm64"
       ],
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4737,11 +4672,13 @@
       "cpu": [
         "x64"
       ],
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4753,11 +4690,13 @@
       "cpu": [
         "arm64"
       ],
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4769,11 +4708,13 @@
       "cpu": [
         "x64"
       ],
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4785,11 +4726,13 @@
       "cpu": [
         "arm64"
       ],
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "os": [
         "openharmony"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4801,11 +4744,13 @@
       "cpu": [
         "x64"
       ],
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "os": [
         "sunos"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4817,11 +4762,13 @@
       "cpu": [
         "arm64"
       ],
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4833,11 +4780,13 @@
       "cpu": [
         "ia32"
       ],
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4849,11 +4798,13 @@
       "cpu": [
         "x64"
       ],
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4889,9 +4840,11 @@
       "version": "0.28.0",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
       "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
-      "extraneous": true,
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,5 +1,6 @@
 @import "tailwindcss";
 @import "./styles/base.css";
+@import "./styles/dark.css";
 @import "./styles/ui.css";
 @import "./styles/layout.css";
 @import "./styles/dashboard.css";

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -31,7 +31,15 @@ export default async function RootLayout({ children }: Readonly<{ children: Reac
   const user = await getCurrentUser();
 
   return (
-    <html lang={defaultLocale}>
+    <html lang={defaultLocale} suppressHydrationWarning>
+      <head>
+        {/* Prevent flash of wrong theme before hydration */}
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `(function(){try{var s=localStorage.getItem('theme'),p=window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light';if((s||p)==='dark')document.documentElement.classList.add('dark');}catch(e){}})();`,
+          }}
+        />
+      </head>
       <body>
         <div className="app-layout">
           <Header user={user} onLogout={logoutAction} />

--- a/src/app/styles/base.css
+++ b/src/app/styles/base.css
@@ -49,6 +49,30 @@
   --shadow-card: 0 1px 3px rgba(15, 23, 42, 0.06), 0 6px 20px rgba(15, 23, 42, 0.10);
 }
 
+.dark {
+  color-scheme: dark;
+
+  --color-bg-canvas: #0f172a;
+  --color-bg-surface: #1e293b;
+  --color-bg-subtle: #162032;
+  --color-border-soft: #2d3f55;
+  --color-border-strong: #3d5270;
+  --color-text-strong: #f1f5f9;
+  --color-text-base: #94a3b8;
+  --color-text-muted: #8fa3b6;
+  --color-accent-soft: #1e3a5f;
+  --color-focus-ring: rgba(59, 130, 246, 0.45);
+
+  --color-accent: #60a5fa;
+  --color-accent-hover: #3b82f6;
+  --color-accent-surface: #1e3a5f;
+  --color-dev-surface: #1c1a08;
+  --color-dev-border: #78450a;
+
+  --shadow-surface: 0 18px 40px rgba(0, 0, 0, 0.35);
+  --shadow-card: 0 1px 3px rgba(0, 0, 0, 0.3), 0 6px 20px rgba(0, 0, 0, 0.25);
+}
+
 @layer base {
   * {
     box-sizing: border-box;

--- a/src/app/styles/dark.css
+++ b/src/app/styles/dark.css
@@ -1,0 +1,203 @@
+/* ── Dark mode — hardcoded color overrides ───────────── */
+
+/* Background: dim wallpaper with a near-opaque dark overlay */
+.dark body {
+  background-image:
+    linear-gradient(rgba(15, 23, 42, 0.80), rgba(15, 23, 42, 0.80)),
+    url('/wallpaper.svg');
+}
+
+/* Site header glass */
+.dark .site-header {
+  background: rgba(15, 23, 42, 0.88);
+}
+
+/* Secondary button — stronger border so it stands out from the surface */
+.dark .ui-button-secondary {
+  border-color: var(--color-border-strong);
+}
+.dark .ui-button-secondary:hover {
+  border-color: #5a7499;
+  background: #243348;
+}
+
+/* Soft button — replace hardcoded light-blue hover with dark equivalent */
+.dark .ui-button.ui-button-soft {
+  border-color: var(--color-border-strong);
+}
+.dark .ui-button.ui-button-soft:hover {
+  background: #1e3a5f;
+  border-color: var(--color-accent);
+}
+
+/* Gradient surface card */
+.dark .ui-surface {
+  background: linear-gradient(180deg, #1e293b 0%, #1a2744 100%);
+}
+
+/* Input error state */
+.dark .ui-input-error {
+  background: #1f0a0c;
+  border-color: #5c2029;
+}
+.dark .ui-input-error:hover,
+.dark .ui-input-error:focus-visible {
+  border-color: #7f2d3a;
+}
+
+/* Button: danger */
+.dark .ui-button-danger {
+  border-color: #5c2029;
+  background: #1f0a0c;
+  color: #fca5a5;
+}
+.dark .ui-button-danger:hover {
+  border-color: #7f2d3a;
+  background: #2d0e12;
+}
+
+/* Messages */
+.dark .ui-message-success {
+  background: #0a1f0f;
+  color: #86efac;
+}
+.dark .ui-message-error {
+  background: #1f0a0c;
+  color: #fca5a5;
+}
+
+/* Badges */
+.dark .ui-badge-available {
+  background: #052e16;
+  color: #4ade80;
+}
+.dark .ui-badge-reserved {
+  background: #2e1065;
+  color: #c4b5fd;
+}
+
+/* Item status strips */
+.dark .item-card-status-available {
+  background: #052e16;
+  color: #4ade80;
+  border-bottom-color: #166534;
+}
+.dark .item-card-status-reserved {
+  background: #2e1065;
+  color: #a78bfa;
+  border-bottom-color: #4c1d95;
+}
+.dark .item-card-status-self-reserved {
+  background: #0c1835;
+  color: #93c5fd;
+  border-bottom-color: #1e3a8a;
+}
+.dark .item-own-badge {
+  background: #1e3a8a;
+  color: #93c5fd;
+}
+
+/* Star button hover */
+.dark .item-star-btn:hover {
+  background: #1c1208;
+}
+.dark .item-star-btn--starred:hover {
+  background: #1c1208;
+}
+
+/* Edit button */
+.dark .item-edit-btn {
+  border-color: #5a7499;
+  background: #243348;
+  color: var(--color-text-base);
+}
+.dark .item-edit-btn:hover {
+  border-color: #6a87af;
+  background: #2d3f55;
+}
+
+/* Cancel reservation button */
+.dark .item-cancel-reservation-btn {
+  border-color: #1e3a8a;
+  background: #0c1835;
+  color: #93c5fd;
+}
+.dark .item-cancel-reservation-btn:hover {
+  border-color: #2563eb;
+  background: #0f2050;
+}
+
+/* Delete button */
+.dark .item-delete-btn {
+  border-color: #5c2029;
+  background: #1f0a0c;
+  color: #fca5a5;
+}
+.dark .item-delete-btn:hover {
+  border-color: #7f2d3a;
+  background: #2d0e12;
+}
+
+/* Copy URL button */
+.dark .share-url-row .copy-url-btn {
+  color: #60a5fa;
+}
+.dark .share-url-row .copy-url-btn:hover {
+  background: #0c1835;
+  color: #60a5fa;
+}
+.dark .copy-url-btn[data-copied="true"] {
+  background: #052e16;
+  border-color: #166534;
+  color: #4ade80;
+}
+.dark .share-url-row .copy-url-btn[data-copied="true"],
+.dark .share-url-row .copy-url-btn[data-copied="true"]:hover,
+.dark .share-url-row .copy-url-btn[data-copied="true"]:active {
+  background: #052e16;
+  border-color: #166534;
+  color: #4ade80;
+}
+
+/* Hero / roadmap description backdrop */
+.dark .home-hero-description,
+.dark .not-found-description {
+  background: rgba(30, 41, 59, 0.82);
+}
+
+/* Roadmap subtitle backdrop */
+.dark .roadmap-subtitle-group {
+  background: rgba(30, 41, 59, 0.82);
+}
+
+/* Roadmap status badges */
+.dark .roadmap-status-released {
+  background: #052e16;
+  color: #4ade80;
+}
+.dark .roadmap-status-in-progress {
+  background: #1e3a5f;
+  color: #93c5fd;
+}
+.dark .roadmap-dot-released {
+  background: #16a34a;
+  border-color: #15803d;
+}
+.dark .roadmap-dot-planned {
+  background: #334155;
+  border-color: #1e293b;
+}
+
+/* Dev block links */
+.dark .home-dev-link {
+  background: rgba(30, 41, 59, 0.7);
+}
+.dark .home-dev-link:hover {
+  background: rgba(30, 41, 59, 0.95);
+  border-color: #f59e0b;
+}
+
+/* Confirm dialog shadow */
+.dark .confirm-dialog {
+  box-shadow: 0 24px 64px rgba(0, 0, 0, 0.5);
+}

--- a/src/app/styles/dashboard.css
+++ b/src/app/styles/dashboard.css
@@ -395,7 +395,8 @@
 
   .item-card-footer {
     display: flex;
-    align-items: center;
+    align-items: stretch;
+    gap: var(--space-6);
     padding: var(--space-3) var(--space-4);
     border-top: 1px solid var(--color-border-soft);
     background: var(--color-bg-subtle);
@@ -405,19 +406,38 @@
   .item-footer-start {
     flex: 1;
     display: flex;
+    justify-content: flex-start;
+    min-width: 0;
   }
 
   .item-footer-center {
+    flex: 1;
     display: flex;
     justify-content: center;
-    flex-shrink: 0;
-    padding: 0 var(--space-2);
+    min-width: 0;
   }
 
   .item-footer-end {
     flex: 1;
     display: flex;
     justify-content: flex-end;
+    min-width: 0;
+  }
+
+  .item-footer-start > .item-edit-btn,
+  .item-footer-end > .item-delete-btn {
+    flex: 1;
+  }
+
+  .item-footer-center > form {
+    flex: 1;
+    display: flex;
+  }
+
+  .item-footer-center > form > button,
+  .item-footer-center > .item-reserve-btn,
+  .item-footer-center > .item-cancel-reservation-btn {
+    flex: 1;
   }
 
   .item-edit-btn {
@@ -512,7 +532,6 @@
     cursor: pointer;
     white-space: nowrap;
     flex-shrink: 0;
-    margin-left: auto;
   }
 
   .item-delete-btn:hover {

--- a/src/app/styles/layout.css
+++ b/src/app/styles/layout.css
@@ -160,6 +160,12 @@
     color: var(--color-text-strong);
   }
 
+  .site-nav-dropdown-item--icon {
+    display: flex;
+    align-items: center;
+    gap: var(--space-3);
+  }
+
   .site-nav-dropdown form {
     display: contents;
   }

--- a/src/modules/i18n/dictionaries/ru/common.ts
+++ b/src/modules/i18n/dictionaries/ru/common.ts
@@ -7,6 +7,8 @@ export const common = {
     reservations: "Мои брони",
     settings: "Настройки",
     accountMenu: "Меню аккаунта",
+    themeDark: "Тёмная тема",
+    themeLight: "Светлая тема",
     logout: "Выйти",
     login: "Войти",
     register: "Создать аккаунт",

--- a/src/shared/ui/nav-links.tsx
+++ b/src/shared/ui/nav-links.tsx
@@ -7,6 +7,115 @@ import { getTranslations } from "@/modules/i18n";
 
 const common = getTranslations("common");
 
+function SunIcon() {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <circle cx="12" cy="12" r="4" />
+      <line x1="12" y1="2" x2="12" y2="4" />
+      <line x1="12" y1="20" x2="12" y2="22" />
+      <line x1="4.22" y1="4.22" x2="5.64" y2="5.64" />
+      <line x1="18.36" y1="18.36" x2="19.78" y2="19.78" />
+      <line x1="2" y1="12" x2="4" y2="12" />
+      <line x1="20" y1="12" x2="22" y2="12" />
+      <line x1="4.22" y1="19.78" x2="5.64" y2="18.36" />
+      <line x1="18.36" y1="5.64" x2="19.78" y2="4.22" />
+    </svg>
+  );
+}
+
+function SettingsIcon() {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <line x1="4" y1="21" x2="4" y2="14" />
+      <line x1="4" y1="10" x2="4" y2="3" />
+      <line x1="12" y1="21" x2="12" y2="12" />
+      <line x1="12" y1="8" x2="12" y2="3" />
+      <line x1="20" y1="21" x2="20" y2="16" />
+      <line x1="20" y1="12" x2="20" y2="3" />
+      <line x1="1" y1="14" x2="7" y2="14" />
+      <line x1="9" y1="8" x2="15" y2="8" />
+      <line x1="17" y1="16" x2="23" y2="16" />
+    </svg>
+  );
+}
+
+function LogoutIcon() {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" />
+      <polyline points="16 17 21 12 16 7" />
+      <line x1="21" y1="12" x2="9" y2="12" />
+    </svg>
+  );
+}
+
+function MoonIcon() {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
+    </svg>
+  );
+}
+
+function useTheme() {
+  const [theme, setTheme] = useState<"light" | "dark">("light");
+
+  useEffect(() => {
+    const stored = localStorage.getItem("theme") as "light" | "dark" | null;
+    const current = document.documentElement.classList.contains("dark") ? "dark" : "light";
+    setTheme(stored ?? current);
+  }, []);
+
+  function toggleTheme() {
+    const next = theme === "dark" ? "light" : "dark";
+    document.documentElement.classList.toggle("dark", next === "dark");
+    localStorage.setItem("theme", next);
+    setTheme(next);
+  }
+
+  return { theme, toggleTheme };
+}
+
 type NavLinksProps = {
   email: string;
   onLogout: () => Promise<void>;
@@ -15,6 +124,7 @@ type NavLinksProps = {
 export function NavLinks({ email, onLogout }: NavLinksProps) {
   const pathname = usePathname();
   const [open, setOpen] = useState(false);
+  const { theme, toggleTheme } = useTheme();
   const isSettingsActive = pathname === "/settings";
   const menuRef = useRef<HTMLDivElement>(null);
 
@@ -72,13 +182,23 @@ export function NavLinks({ email, onLogout }: NavLinksProps) {
             <div className="site-nav-dropdown-divider" />
             <Link
               href="/settings"
-              className="site-nav-dropdown-item"
+              className="site-nav-dropdown-item site-nav-dropdown-item--icon"
               onClick={() => setOpen(false)}
             >
+              <SettingsIcon />
               {common.nav.settings}
             </Link>
+            <button
+              type="button"
+              className="site-nav-dropdown-item site-nav-dropdown-item--icon"
+              onClick={toggleTheme}
+            >
+              {theme === "dark" ? <SunIcon /> : <MoonIcon />}
+              {theme === "dark" ? common.nav.themeLight : common.nav.themeDark}
+            </button>
             <form action={onLogout}>
-              <button type="submit" className="site-nav-dropdown-item">
+              <button type="submit" className="site-nav-dropdown-item site-nav-dropdown-item--icon">
+                <LogoutIcon />
                 {common.nav.logout}
               </button>
             </form>
@@ -91,9 +211,54 @@ export function NavLinks({ email, onLogout }: NavLinksProps) {
 
 export function GuestLinks() {
   const pathname = usePathname();
+  const { theme, toggleTheme } = useTheme();
 
   return (
     <nav className="site-nav site-nav--guest">
+      <button
+        type="button"
+        className="site-nav-gear"
+        aria-label={theme === "dark" ? common.nav.themeLight : common.nav.themeDark}
+        onClick={toggleTheme}
+      >
+        {theme === "dark" ? (
+          <svg
+            width="20"
+            height="20"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden="true"
+          >
+            <circle cx="12" cy="12" r="4" />
+            <line x1="12" y1="2" x2="12" y2="4" />
+            <line x1="12" y1="20" x2="12" y2="22" />
+            <line x1="4.22" y1="4.22" x2="5.64" y2="5.64" />
+            <line x1="18.36" y1="18.36" x2="19.78" y2="19.78" />
+            <line x1="2" y1="12" x2="4" y2="12" />
+            <line x1="20" y1="12" x2="22" y2="12" />
+            <line x1="4.22" y1="19.78" x2="5.64" y2="18.36" />
+            <line x1="18.36" y1="5.64" x2="19.78" y2="4.22" />
+          </svg>
+        ) : (
+          <svg
+            width="20"
+            height="20"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden="true"
+          >
+            <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
+          </svg>
+        )}
+      </button>
       <Link
         href="/login"
         className={`site-nav-link${pathname === "/login" ? " site-nav-link--active" : ""}`}

--- a/tests/e2e/dark-theme.spec.ts
+++ b/tests/e2e/dark-theme.spec.ts
@@ -1,0 +1,82 @@
+import { randomUUID } from "node:crypto";
+import { expect, test, type Page } from "@playwright/test";
+
+// ── Guest toggle ──────────────────────────────────────────
+
+test("guest can toggle to dark theme via nav button", async ({ page }) => {
+  await page.goto("/");
+
+  await expect(page.locator("html")).not.toHaveClass(/dark/);
+
+  await page.getByRole("button", { name: "Тёмная тема" }).click();
+
+  await expect(page.locator("html")).toHaveClass(/dark/);
+});
+
+test("theme preference persists after page reload", async ({ page }) => {
+  await page.goto("/");
+  await page.getByRole("button", { name: "Тёмная тема" }).click();
+  await expect(page.locator("html")).toHaveClass(/dark/);
+
+  await page.reload();
+
+  await expect(page.locator("html")).toHaveClass(/dark/);
+});
+
+test("guest can switch back to light theme", async ({ page }) => {
+  await page.goto("/");
+  await page.getByRole("button", { name: "Тёмная тема" }).click();
+  await expect(page.locator("html")).toHaveClass(/dark/);
+
+  await page.getByRole("button", { name: "Светлая тема" }).click();
+
+  await expect(page.locator("html")).not.toHaveClass(/dark/);
+});
+
+// ── System preference default ─────────────────────────────
+
+test("first visit with dark system preference applies dark class", async ({ browser }) => {
+  const context = await browser.newContext({ colorScheme: "dark" });
+  const page = await context.newPage();
+
+  await page.goto("/");
+
+  await expect(page.locator("html")).toHaveClass(/dark/);
+  await context.close();
+});
+
+test("first visit with light system preference does not apply dark class", async ({ browser }) => {
+  const context = await browser.newContext({ colorScheme: "light" });
+  const page = await context.newPage();
+
+  await page.goto("/");
+
+  await expect(page.locator("html")).not.toHaveClass(/dark/);
+  await context.close();
+});
+
+// ── Authenticated user toggle ─────────────────────────────
+
+test("authenticated user can toggle theme via gear dropdown", async ({ page }) => {
+  await registerUser(page);
+
+  await expect(page.locator("html")).not.toHaveClass(/dark/);
+
+  await page.getByRole("button", { name: "Меню аккаунта" }).click();
+  await page.getByRole("button", { name: "Тёмная тема" }).click();
+
+  await expect(page.locator("html")).toHaveClass(/dark/);
+});
+
+// ── Helpers ───────────────────────────────────────────────
+
+async function registerUser(page: Page) {
+  const runId = randomUUID().slice(0, 12);
+  await page.goto("/register");
+  await page.getByLabel("Email").fill(`theme-${runId}@example.com`);
+  await page.getByLabel("Пароль", { exact: true }).fill(`Theme!${runId}`);
+  await page.getByLabel("Повторите пароль").fill(`Theme!${runId}`);
+  await page.locator("#consent").check();
+  await page.getByRole("button", { name: "Создать аккаунт" }).click();
+  await expect(page).toHaveURL(/\/(?:\?.*)?$/);
+}


### PR DESCRIPTION
Closes #156.

Delivers dark theme for all routes with no flash on load.

## What changed

- `styles/base.css` — `.dark` block overrides all 16 design tokens
- `styles/dark.css` — new file; hardcoded palette overrides for
  badges, status strips, buttons, and backgrounds
- `layout.tsx` — inline script in `<head>` applies `.dark` class
  before hydration; `suppressHydrationWarning` on `<html>`
- `nav-links.tsx` — theme toggle (sun/moon SVG icons) in gear
  dropdown for authenticated users; standalone icon button in
  `GuestLinks`; `useTheme` hook shared between both
- `ru/common.ts` — `themeDark` / `themeLight` i18n keys
- `dashboard.css` — item card footer: three equal-width buttons,
  edge-aligned, consistent gap

## How to verify

- Open the app with `prefers-color-scheme: dark` — dark theme
  applies immediately with no flash
- Toggle via the gear menu (auth) or nav button (guest) —
  switches instantly without reload
- Reload — chosen theme is preserved
- Check all routes in both themes

## Tests

- `tests/e2e/dark-theme.spec.ts` — 6 scenarios: guest toggle,
  persistence after reload, light/dark system preference default,
  authenticated user toggle via dropdown

## Documentation

- `CHANGELOG.md` — Unreleased section updated
- `docs/master-plan.md` — M10-I1 marked done; M10-I2 parallax
  added; remaining issues renumbered