### PR TITLE
feat(ui): background parallax with pointer and scroll depth effect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ The format is based on Keep a Changelog, and this project follows SemVer.
 ## [Unreleased]
 
 ### Added
+- Background parallax: wallpaper pattern is rendered on a viewport-fixed
+  `body::before` pseudo-element. A `WallpaperParallax` client component
+  drives two combined inputs — `pointermove` shifts the layer ±20 px
+  opposite to the pointer (depth-through-window effect); `wheel` and
+  `scroll` events re-read `window.scrollY` and map it as a fraction of
+  total page height to a fixed ±90 px range, so the effect is evenly
+  distributed across any page length. `wheel` covers Mac trackpad
+  momentum; `scroll` covers mobile touch scroll. Both are RAF-throttled.
+  `prefers-reduced-motion: reduce` disables the component entirely.
+  Dark mode dims the wallpaper layer via `opacity: 0.18` instead of
+  the previous gradient overlay.
+
+### Changed
+- Site header: removed `backdrop-filter: blur(12px)` for performance;
+  background opacity raised from 0.88 to 0.92 to compensate.
+- Site layout: added `overscroll-behavior: none` on `<html>` to prevent
+  rubber-band overscroll from exposing the fixed wallpaper layer behind
+  the header and footer.
+- Mobile header: logo text («Wshka») is now hidden at ≤479 px on all
+  nav states (was hidden for authenticated users only), freeing space
+  for the theme toggle.
 - Dark theme: CSS custom property overrides under `.dark` class on `<html>`;
   all design tokens and hardcoded palette values have dark equivalents.
 - Theme toggle in the account menu (gear icon dropdown): switches immediately

--- a/docs/master-plan.md
+++ b/docs/master-plan.md
@@ -96,7 +96,7 @@ Status:
 
 Execution backlog:
 1. ✅ Dark theme — CSS variable toggle, `localStorage` persistence, `prefers-color-scheme` default
-2. Background parallax — subtle depth effect on the wallpaper pattern, CSS or JS-driven
+2. ✅ Background parallax — subtle depth effect on the wallpaper pattern, CSS or JS-driven
 3. English locale — `en/` i18n dictionary, locale switcher in header, browser auto-detect
 4. Multiple currencies — currency preference per user profile, locale-aware display formatting
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,6 +5,7 @@ import { getCurrentUser } from "@/modules/auth/server/current-user";
 import { Header } from "@/shared/ui/header";
 import { Footer } from "@/shared/ui/footer";
 import { CookieBanner } from "@/shared/ui/cookie-banner";
+import { WallpaperParallax } from "@/shared/ui/wallpaper-parallax";
 import { logoutAction } from "@/app/auth-actions";
 import "./globals.css";
 
@@ -41,6 +42,7 @@ export default async function RootLayout({ children }: Readonly<{ children: Reac
         />
       </head>
       <body>
+        <WallpaperParallax />
         <div className="app-layout">
           <Header user={user} onLogout={logoutAction} />
           <main className="app-main">{children}</main>

--- a/src/app/styles/base.css
+++ b/src/app/styles/base.css
@@ -81,20 +81,34 @@
   html {
     background: var(--color-bg-canvas);
     overflow-x: clip;
+    overscroll-behavior: none;
   }
 
   body {
     margin: 0;
     min-height: 100vh;
-    background-color: var(--color-bg-canvas);
-    background-image: url('/wallpaper.svg');
-    background-size: 200px 200px;
-    background-repeat: repeat;
     color: var(--color-text-strong);
     font-family: var(--font-sans);
     font-size: var(--font-size-body);
     line-height: var(--line-height-body);
     text-rendering: optimizeLegibility;
+  }
+
+  /* Wallpaper on a fixed pseudo-element for parallax depth.
+     Using ::before + position:fixed is more reliable than
+     background-attachment:fixed when a parent has overflow-x:clip.
+     inset:-50px extends beyond the viewport so edges stay covered
+     when JS shifts the layer via --wp-x / --wp-y (max ±20 px). */
+  body::before {
+    content: '';
+    position: fixed;
+    inset: -120px;
+    z-index: -1;
+    pointer-events: none;
+    background-image: url('/wallpaper.svg');
+    background-size: 200px 200px;
+    background-repeat: repeat;
+    transform: translate(var(--wp-x, 0px), var(--wp-y, 0px));
   }
 
   a {

--- a/src/app/styles/dark.css
+++ b/src/app/styles/dark.css
@@ -1,15 +1,13 @@
 /* ── Dark mode — hardcoded color overrides ───────────── */
 
-/* Background: dim wallpaper with a near-opaque dark overlay */
-.dark body {
-  background-image:
-    linear-gradient(rgba(15, 23, 42, 0.80), rgba(15, 23, 42, 0.80)),
-    url('/wallpaper.svg');
+/* Background: dim wallpaper by reducing pseudo-element opacity */
+.dark body::before {
+  opacity: 0.18;
 }
 
-/* Site header glass */
+/* Site header */
 .dark .site-header {
-  background: rgba(15, 23, 42, 0.88);
+  background: rgba(15, 23, 42, 0.92);
 }
 
 /* Secondary button — stronger border so it stands out from the surface */

--- a/src/app/styles/layout.css
+++ b/src/app/styles/layout.css
@@ -5,9 +5,7 @@
     top: 0;
     z-index: 50;
     border-bottom: 1px solid var(--color-border-soft);
-    background: rgba(255, 255, 255, 0.88);
-    backdrop-filter: blur(12px);
-    -webkit-backdrop-filter: blur(12px);
+    background: rgba(255, 255, 255, 0.92);
   }
 
   .site-header-inner {
@@ -61,7 +59,7 @@
   }
 
   @media (max-width: 479px) {
-    .site-header-inner:not(:has(.site-nav--guest)) .site-logo-text {
+    .site-logo-text {
       display: none;
     }
   }

--- a/src/shared/ui/wallpaper-parallax.tsx
+++ b/src/shared/ui/wallpaper-parallax.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { useEffect } from "react";
+
+/**
+ * Drives the wallpaper parallax via two combined inputs:
+ *
+ *  • pointermove (mouse / touch drag) — shifts the layer ±20 px on X and Y,
+ *    opposite to pointer direction, creating a depth-through-window effect.
+ *
+ *  • scroll + wheel — both trigger a re-read of window.scrollY.
+ *    `wheel` catches Mac trackpad gestures (incl. momentum scroll).
+ *    `scroll` catches mobile touch scroll (wheel does not fire on touch).
+ *    The offset is a fraction of total page height mapped to SCROLL_MAX px,
+ *    so the effect is distributed evenly regardless of page length.
+ *
+ * window.scrollY is always the ground truth — no delta accumulation.
+ * Both inputs are RAF-throttled and write to --wp-x / --wp-y on <html>.
+ * Disabled entirely when prefers-reduced-motion: reduce is set.
+ */
+export function WallpaperParallax() {
+  useEffect(() => {
+    if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) return;
+
+    const MOUSE_INTENSITY = 40; // full range in px; actual offset is ±20 px
+    const SCROLL_MAX = 90; // total background shift at full-page scroll (px)
+
+    let mouseX = window.innerWidth / 2;
+    let mouseY = window.innerHeight / 2;
+    let rafId: number;
+
+    const update = () => {
+      const mx = (0.5 - mouseX / window.innerWidth) * MOUSE_INTENSITY;
+      const my = (0.5 - mouseY / window.innerHeight) * MOUSE_INTENSITY;
+
+      // Fraction of page scrolled (0 at top → 1 at bottom).
+      // Guard against non-scrollable pages (scrollable === 0).
+      const scrollable = document.body.scrollHeight - window.innerHeight;
+      const fraction = scrollable > 0 ? window.scrollY / scrollable : 0;
+      const sy = -fraction * SCROLL_MAX;
+
+      const root = document.documentElement;
+      root.style.setProperty("--wp-x", `${mx.toFixed(2)}px`);
+      root.style.setProperty("--wp-y", `${(my + sy).toFixed(2)}px`);
+    };
+
+    const onPointerMove = (e: PointerEvent) => {
+      mouseX = e.clientX;
+      mouseY = e.clientY;
+      cancelAnimationFrame(rafId);
+      rafId = requestAnimationFrame(update);
+    };
+
+    // Shared trigger for both wheel and scroll events.
+    // wheel  → Mac trackpad / mouse wheel (does not fire on mobile touch scroll)
+    // scroll → mobile touch scroll (fires as window.scrollY changes)
+    const onScrollTrigger = () => {
+      cancelAnimationFrame(rafId);
+      rafId = requestAnimationFrame(update);
+    };
+
+    update();
+
+    window.addEventListener("pointermove", onPointerMove, { passive: true });
+    window.addEventListener("wheel", onScrollTrigger, { passive: true });
+    window.addEventListener("scroll", onScrollTrigger, { passive: true });
+
+    return () => {
+      window.removeEventListener("pointermove", onPointerMove);
+      window.removeEventListener("wheel", onScrollTrigger);
+      window.removeEventListener("scroll", onScrollTrigger);
+      cancelAnimationFrame(rafId);
+    };
+  }, []);
+
+  return null;
+}

--- a/tests/e2e/parallax-wallpaper.spec.ts
+++ b/tests/e2e/parallax-wallpaper.spec.ts
@@ -1,0 +1,90 @@
+import { expect, test } from "@playwright/test";
+
+/**
+ * E2E tests for the parallax wallpaper feature (M10-I2).
+ *
+ * Unit tests verify CSS file content; these tests verify that the CSS and
+ * the WallpaperParallax client component actually behave correctly in a
+ * real browser.
+ */
+
+test.describe("parallax wallpaper", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/");
+    // Wait for Next.js client-side hydration so WallpaperParallax mounts
+    await page.waitForLoadState("networkidle");
+  });
+
+  test("body::before pseudo-element is position:fixed", async ({ page }) => {
+    const position = await page.evaluate(() =>
+      window.getComputedStyle(document.body, "::before").position,
+    );
+    expect(position).toBe("fixed");
+  });
+
+  test("html element has overscroll-behavior: none", async ({ page }) => {
+    const value = await page.evaluate(
+      () => window.getComputedStyle(document.documentElement).overscrollBehavior,
+    );
+    expect(value).toBe("none");
+  });
+
+  test("site header has no backdrop-filter", async ({ page }) => {
+    const value = await page.evaluate(() => {
+      const header = document.querySelector(".site-header");
+      return header ? window.getComputedStyle(header).backdropFilter : null;
+    });
+    expect(value).toBe("none");
+  });
+
+  test("WallpaperParallax sets --wp-x and --wp-y after pointer move", async ({
+    page,
+  }) => {
+    await page.mouse.move(400, 300);
+    await page.waitForTimeout(50);
+
+    const [wpX, wpY] = await page.evaluate(() => [
+      document.documentElement.style.getPropertyValue("--wp-x"),
+      document.documentElement.style.getPropertyValue("--wp-y"),
+    ]);
+
+    expect(wpX).toMatch(/^-?\d+\.\d+px$/);
+    expect(wpY).toMatch(/^-?\d+\.\d+px$/);
+  });
+
+  test("--wp-x changes direction when cursor crosses the viewport centre", async ({
+    page,
+  }) => {
+    const width = page.viewportSize()!.width;
+
+    // Move to left edge and wait for RAF to write the CSS var
+    await page.mouse.move(10, 300);
+    await page.waitForTimeout(50);
+    const leftX = await page.evaluate(() =>
+      document.documentElement.style.getPropertyValue("--wp-x"),
+    );
+
+    // Move to right edge (stay 10px inside to stay within the viewport)
+    await page.mouse.move(width - 10, 300);
+    await page.waitForTimeout(50);
+    const rightX = await page.evaluate(() =>
+      document.documentElement.style.getPropertyValue("--wp-x"),
+    );
+
+    const left = parseFloat(leftX);
+    const right = parseFloat(rightX);
+    // Left-of-centre → positive offset; right-of-centre → negative offset
+    expect(left).toBeGreaterThan(0);
+    expect(right).toBeLessThan(0);
+  });
+
+  test("logo text is hidden on mobile viewport", async ({ page }) => {
+    await page.setViewportSize({ width: 375, height: 812 });
+    await expect(page.locator(".site-logo-text")).toBeHidden();
+  });
+
+  test("logo text is visible on desktop viewport", async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 800 });
+    await expect(page.locator(".site-logo-text")).toBeVisible();
+  });
+});

--- a/tests/unit/parallax-wallpaper.test.ts
+++ b/tests/unit/parallax-wallpaper.test.ts
@@ -10,6 +10,10 @@ const darkCSS = readFileSync(
   resolve(__dirname, "../../src/app/styles/dark.css"),
   "utf-8",
 );
+const layoutCSS = readFileSync(
+  resolve(__dirname, "../../src/app/styles/layout.css"),
+  "utf-8",
+);
 const componentSrc = readFileSync(
   resolve(__dirname, "../../src/shared/ui/wallpaper-parallax.tsx"),
   "utf-8",
@@ -132,6 +136,26 @@ describe("parallax wallpaper", () => {
 
     it("removes the event listener on unmount", () => {
       expect(componentSrc).toContain("removeEventListener");
+    });
+  });
+
+  describe("base.css — overscroll", () => {
+    it("disables rubber-band overscroll to prevent gaps behind header and footer", () => {
+      expect(baseCSS).toContain("overscroll-behavior: none");
+    });
+  });
+
+  describe("layout.css — site header", () => {
+    it("does not use backdrop-filter (removed for performance)", () => {
+      expect(layoutCSS).not.toContain("backdrop-filter");
+    });
+  });
+
+  describe("layout.css — mobile logo", () => {
+    it("hides logo text on all nav states at <=479px", () => {
+      // Selector must be simple .site-logo-text, not scoped to auth-only
+      expect(layoutCSS).toContain(".site-logo-text");
+      expect(layoutCSS).not.toContain("site-nav--guest");
     });
   });
 });

--- a/tests/unit/parallax-wallpaper.test.ts
+++ b/tests/unit/parallax-wallpaper.test.ts
@@ -1,0 +1,137 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const baseCSS = readFileSync(
+  resolve(__dirname, "../../src/app/styles/base.css"),
+  "utf-8",
+);
+const darkCSS = readFileSync(
+  resolve(__dirname, "../../src/app/styles/dark.css"),
+  "utf-8",
+);
+const componentSrc = readFileSync(
+  resolve(__dirname, "../../src/shared/ui/wallpaper-parallax.tsx"),
+  "utf-8",
+);
+
+describe("parallax wallpaper", () => {
+  describe("base.css — fixed layer", () => {
+    it("declares body::before pseudo-element", () => {
+      expect(baseCSS).toContain("body::before");
+    });
+
+    it("fixes the pseudo-element to the viewport", () => {
+      expect(baseCSS).toContain("position: fixed");
+    });
+
+    it("places the wallpaper layer behind content", () => {
+      expect(baseCSS).toContain("z-index: -1");
+    });
+
+    it("extends beyond viewport edges so shifts stay covered", () => {
+      expect(baseCSS).toContain("inset: -120px");
+    });
+
+    it("does not set background-color on body (would cover z-index:-1 layer)", () => {
+      const bodyBlockMatch = baseCSS.match(/\bbody\s*\{([^}]+)\}/);
+      expect(bodyBlockMatch).not.toBeNull();
+      expect(bodyBlockMatch![1]).not.toContain("background-color");
+    });
+
+    it("serves the wallpaper via body::before, not via body background-image", () => {
+      const beforeIndex = baseCSS.indexOf("body::before");
+      const wallpaperIndex = baseCSS.indexOf("url('/wallpaper.svg')");
+      expect(beforeIndex).toBeGreaterThan(-1);
+      expect(wallpaperIndex).toBeGreaterThan(-1);
+      expect(wallpaperIndex).toBeGreaterThan(beforeIndex);
+    });
+  });
+
+  describe("base.css — pointer-driven parallax", () => {
+    it("uses CSS custom properties for the parallax offset", () => {
+      expect(baseCSS).toContain("--wp-x");
+      expect(baseCSS).toContain("--wp-y");
+    });
+
+    it("applies offset via transform translate for composited animation", () => {
+      expect(baseCSS).toContain(
+        "transform: translate(var(--wp-x, 0px), var(--wp-y, 0px))",
+      );
+    });
+
+    it("does not use will-change so backdrop-filter on the header can see the layer", () => {
+      expect(baseCSS).not.toContain("will-change");
+    });
+  });
+
+  describe("base.css — accessibility", () => {
+    it("respects prefers-reduced-motion in the client component", () => {
+      expect(componentSrc).toContain("prefers-reduced-motion");
+    });
+  });
+
+  describe("dark.css — dark mode integration", () => {
+    it("dims the wallpaper pseudo-element in dark mode via opacity", () => {
+      expect(darkCSS).toContain(".dark body::before");
+      expect(darkCSS).toContain("opacity");
+    });
+
+    it("does not override body background-image in dark mode", () => {
+      expect(darkCSS).not.toContain("url('/wallpaper.svg')");
+    });
+  });
+
+  describe("wallpaper-parallax.tsx — client component", () => {
+    it("is marked as a client component", () => {
+      expect(componentSrc).toContain('"use client"');
+    });
+
+    it("listens for pointermove events", () => {
+      expect(componentSrc).toContain("pointermove");
+    });
+
+    it("listens for wheel events (Mac trackpad incl. momentum scrolling)", () => {
+      expect(componentSrc).toContain('"wheel"');
+    });
+
+    it("listens for scroll events (mobile touch scroll)", () => {
+      expect(componentSrc).toContain('"scroll"');
+    });
+
+    it("uses window.scrollY as ground truth, not accumulated wheel deltas", () => {
+      expect(componentSrc).toContain("window.scrollY");
+      expect(componentSrc).not.toContain("wheelAccum");
+    });
+
+    it("maps scroll to a fraction of total page height for even distribution", () => {
+      expect(componentSrc).toContain("scrollable");
+      expect(componentSrc).toContain("fraction");
+    });
+
+    it("guards against division by zero on non-scrollable pages", () => {
+      expect(componentSrc).toContain("scrollable > 0");
+    });
+
+    it("applies initial state on mount without waiting for the first event", () => {
+      expect(componentSrc).toContain("update()");
+    });
+
+    it("uses requestAnimationFrame for throttling", () => {
+      expect(componentSrc).toContain("requestAnimationFrame");
+    });
+
+    it("sets --wp-x and --wp-y custom properties", () => {
+      expect(componentSrc).toContain("--wp-x");
+      expect(componentSrc).toContain("--wp-y");
+    });
+
+    it("respects prefers-reduced-motion", () => {
+      expect(componentSrc).toContain("prefers-reduced-motion");
+    });
+
+    it("removes the event listener on unmount", () => {
+      expect(componentSrc).toContain("removeEventListener");
+    });
+  });
+});


### PR DESCRIPTION
Closes #158.

Adds a depth-parallax effect to the tiled wallpaper background,
driven by pointer movement and page scroll.

## What changed

- `body::before` (position: fixed, inset: -120px) replaces the inline
  body background — avoids `background-attachment: fixed` quirks with
  `overflow-x: clip` on `<html>`.
- `WallpaperParallax` client component listens to `pointermove`,
  `wheel`, and `scroll`; writes `--wp-x` / `--wp-y` to `<html>`;
  wallpaper layer applies them via `transform: translate()`.
- Pointer offset: ±20 px opposite cursor direction.
- Scroll offset: `scrollY / scrollableHeight × 90 px`, distributed
  evenly across any page length. `wheel` covers Mac trackpad momentum;
  `scroll` covers mobile touch.
- `prefers-reduced-motion: reduce` disables the component entirely.
- Dark mode: wallpaper dimmed via `opacity: 0.18` (replaces gradient
  overlay); header background raised to 0.92 opacity.
- `overscroll-behavior: none` on `<html>` prevents rubber-band
  overscroll from exposing gaps between the fixed layer and sticky
  header / footer.
- Logo text hidden at ≤479 px on all nav states (was auth-only).

## How to verify

- Move the cursor across any page — wallpaper shifts subtly opposite
  to cursor direction.
- Scroll up/down — wallpaper shifts proportionally through the full
  page height.
- On Mac trackpad: two-finger scroll produces smooth continuous shift.
- On mobile: touch scroll produces smooth continuous shift.
- Fast/hard scroll to page edges — header and footer stay anchored,
  no background gap visible.
- Toggle dark mode — wallpaper remains subtly visible, no gradient
  overlay artifact.
- Enable prefers-reduced-motion — no parallax movement.

## Tests

- `tests/unit/parallax-wallpaper.test.ts` — 23 tests covering CSS
  layer structure, transform wiring, event listeners, scroll math,
  RAF throttling, reduced-motion, and dark mode integration.

## Documentation

- `CHANGELOG.md` — Unreleased section updated.
- `docs/master-plan.md` — M10-I2 marked ✅.