### PR TITLE
feat(wishlist): export and import as human-readable Markdown backup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on Keep a Changelog, and this project follows SemVer.
 - QR code for share links: QR button in the share URL row opens a modal with
   a scannable code; owner can download it as PNG. Browser-side only via
   `qrcode.react`; no backend changes.
+- Wishlist backup: owner can export all wishlists (or a single one) as a
+  human-readable Markdown file and re-import it to restore data. Export via
+  `GET /api/wishlist/export`; import via file-upload modal on the dashboard.
+  Existing data is never overwritten — import always creates new lists.
 
 ## [1.2.0] - 2026-05-12
 

--- a/docs/master-plan.md
+++ b/docs/master-plan.md
@@ -102,17 +102,17 @@ Status:
 
 Execution backlog:
 1. ✅ QR code for share links — browser-side generation, modal or inline display
-2. Export / import wishlist — JSON download, JSON upload with item creation
+2. ✅ Export / import wishlist — download all wishlists as a human-readable formatted text file; import back from the same file to restore items
 3. Item image upload — local VPS storage, Caddy serving, `imageUrl` column
 
 Recommended issue shape:
 - `M11-I1 QR code for share links — browser-side generation and display`
-- `M11-I2 Export / import wishlist — JSON download and upload`
+- `M11-I2 Export / import wishlist — formatted text backup download and restore`
 - `M11-I3 Item image upload — VPS local storage, Caddy config, schema addition`
 
 Recommended PR order:
 1. `M11-I1 QR code for share links — browser-side generation and display`
-2. `M11-I2 Export / import wishlist — JSON download and upload`
+2. `M11-I2 Export / import wishlist — formatted text backup download and restore`
 3. `M11-I3 Item image upload — VPS local storage, Caddy config, schema addition`
 
 Dependencies:
@@ -122,27 +122,27 @@ Dependencies:
 
 Scope notes:
 - QR code must be generated entirely in the browser; no backend endpoint required. Use a small, well-maintained library (e.g. `qrcode`).
-- Export format is a plain JSON array of items (title, url, note, price, priority). Import creates new items in the current wishlist; it does not overwrite or merge.
+- Export format is a human-readable Markdown file containing all the owner's wishlists: each wishlist as a named section, each item as a Markdown table row (title, url, note, price, currency). The file is designed to be stored, shared, or read without the app. Import parses the same Markdown format and recreates the wishlists and their items; it does not overwrite or merge existing data.
 - Image upload is one image per item, stored at `/uploads/<uuid>.<ext>` on the VPS. Caddy serves the directory as static files. The `imageUrl` column stores the relative path. Max file size enforced at the Next.js API layer.
 - Do not add S3 or CDN in this milestone — local VPS storage is the explicit target.
 
 Acceptance targets:
 - owner can open a QR code for an active share link and download or share it
-- owner can download their wishlist as a JSON file and re-import it to restore items
+- owner can download all their wishlists as a single human-readable Markdown file, suitable for storage, sharing, or printing; the file can be re-imported to restore wishlists and items
 - owner can upload one image per item; image is shown on the dashboard and the share page
 
 Exit criteria:
 - QR modal works without a server round-trip
-- exported JSON is valid and round-trips through import without data loss
+- exported Markdown is valid, human-readable, and round-trips through import without data loss
 - uploaded images are served at a stable URL; Caddy config updated; `imageUrl` migration applied
 
 Definition of small PRs for this milestone:
 - QR PR only adds the client-side QR component and wires it to the share link block; does not touch the backend
-- export/import PR only adds the download action and the upload/parse flow; does not touch image or QR logic
+- export/import PR only adds the Markdown download action, the file-upload/parse flow, and the dashboard UI entry points; does not touch image or QR logic
 - image PR only adds the upload API route, the `imageUrl` migration, Caddy static-file config, and item card image rendering
 
 Release note:
-- `v1.3.0` adds QR code sharing, wishlist JSON export/import, and per-item image upload.
+- `v1.3.0` adds QR code sharing, wishlist backup export/import (human-readable Markdown), and per-item image upload.
 
 ---
 

--- a/src/app/_dashboard/backup-dropdown.tsx
+++ b/src/app/_dashboard/backup-dropdown.tsx
@@ -1,0 +1,312 @@
+"use client";
+
+import { useRef, useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+
+type BackupLabels = {
+  exportAllLabel: string;
+  exportOneLabel: string;
+  importLabel: string;
+  importDialogTitle: string;
+  importDialogDescription: string;
+  importFileLabel: string;
+  importSubmitLabel: string;
+  importCancelLabel: string;
+  importSuccess: string;
+  importErrorEmpty: string;
+  importErrorInvalidFormat: string;
+  importErrorNoWishlists: string;
+  importErrorUnknown: string;
+};
+
+type ImportResult =
+  | { status: "success"; wishlists: number; items: number }
+  | { status: "error"; code: "empty" | "invalid-format" | "no-wishlists" | "unknown" };
+
+type BackupDropdownProps = {
+  /** ID of the currently selected wishlist — used for single-list export. */
+  selectedWishlistId: string;
+  labels: BackupLabels;
+  importAction: (text: string) => Promise<ImportResult>;
+  /** Label shown on the trigger button. */
+  triggerLabel: string;
+};
+
+function ChevronDownIcon() {
+  return (
+    <svg
+      width="12"
+      height="12"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+      style={{ flexShrink: 0 }}
+    >
+      <polyline points="6 9 12 15 18 9" />
+    </svg>
+  );
+}
+
+function BackupIcon() {
+  return (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+      style={{ flexShrink: 0 }}
+    >
+      <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+      <polyline points="7 10 12 15 17 10" />
+      <line x1="12" y1="15" x2="12" y2="3" />
+    </svg>
+  );
+}
+
+export function BackupDropdown({
+  selectedWishlistId,
+  labels,
+  importAction,
+  triggerLabel,
+}: BackupDropdownProps) {
+  const [open, setOpen] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+  const dialogRef = useRef<HTMLDialogElement>(null);
+  const fileRef = useRef<HTMLInputElement>(null);
+  const [feedback, setFeedback] = useState<string | null>(null);
+  const [feedbackOk, setFeedbackOk] = useState(false);
+  const [isPending, startTransition] = useTransition();
+  const router = useRouter();
+
+  // Close dropdown on outside click
+  function handleDropdownOutside(e: MouseEvent) {
+    if (dropdownRef.current && !dropdownRef.current.contains(e.target as Node)) {
+      setOpen(false);
+      document.removeEventListener("mousedown", handleDropdownOutside);
+    }
+  }
+
+  function toggleDropdown() {
+    setOpen((v) => {
+      if (!v) {
+        document.addEventListener("mousedown", handleDropdownOutside);
+      } else {
+        document.removeEventListener("mousedown", handleDropdownOutside);
+      }
+      return !v;
+    });
+  }
+
+  function exportOne() {
+    setOpen(false);
+    const url = `/api/wishlist/export?wishlistId=${encodeURIComponent(selectedWishlistId)}`;
+    const a = document.createElement("a");
+    a.href = url;
+    a.click();
+  }
+
+  function exportAll() {
+    setOpen(false);
+    const a = document.createElement("a");
+    a.href = "/api/wishlist/export";
+    a.click();
+  }
+
+  function openImportDialog() {
+    setOpen(false);
+    setFeedback(null);
+    setFeedbackOk(false);
+    if (fileRef.current) fileRef.current.value = "";
+    dialogRef.current?.showModal();
+  }
+
+  function closeImportDialog() {
+    dialogRef.current?.close();
+  }
+
+  function handleBackdropClick(e: React.MouseEvent<HTMLDialogElement>) {
+    if (e.target === e.currentTarget) closeImportDialog();
+  }
+
+  function formatSuccess(wishlists: number, items: number): string {
+    return labels.importSuccess
+      .replace("{wishlists}", String(wishlists))
+      .replace("{items}", String(items));
+  }
+
+  function errorMessage(code: "empty" | "invalid-format" | "no-wishlists" | "unknown"): string {
+    switch (code) {
+      case "empty": return labels.importErrorEmpty;
+      case "invalid-format": return labels.importErrorInvalidFormat;
+      case "no-wishlists": return labels.importErrorNoWishlists;
+      default: return labels.importErrorUnknown;
+    }
+  }
+
+  async function handleImportSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    const file = fileRef.current?.files?.[0];
+    if (!file) return;
+    const text = await file.text();
+    startTransition(async () => {
+      const result = await importAction(text);
+      if (result.status === "success") {
+        setFeedback(formatSuccess(result.wishlists, result.items));
+        setFeedbackOk(true);
+        router.refresh();
+      } else {
+        setFeedback(errorMessage(result.code));
+        setFeedbackOk(false);
+      }
+    });
+  }
+
+  return (
+    <>
+      {/* Trigger + dropdown */}
+      <div ref={dropdownRef} style={{ position: "relative" }}>
+        <button
+          type="button"
+          className="ui-button ui-button-soft"
+          onClick={toggleDropdown}
+          aria-expanded={open}
+          aria-haspopup="menu"
+          data-testid="backup-dropdown-trigger"
+        >
+          <BackupIcon />
+          <span className="wishlist-btn-label">{triggerLabel}</span>
+          <ChevronDownIcon />
+        </button>
+
+        {open && (
+          <ul
+            role="menu"
+            className="backup-dropdown-menu"
+            data-testid="backup-dropdown-menu"
+          >
+            <li role="none">
+              <button
+                type="button"
+                role="menuitem"
+                className="backup-dropdown-item"
+                onClick={exportOne}
+                data-testid="export-wishlist-btn"
+              >
+                {labels.exportOneLabel}
+              </button>
+            </li>
+            <li role="none">
+              <button
+                type="button"
+                role="menuitem"
+                className="backup-dropdown-item"
+                onClick={exportAll}
+                data-testid="export-all-btn"
+              >
+                {labels.exportAllLabel}
+              </button>
+            </li>
+            <li role="none" className="backup-dropdown-separator" aria-hidden="true" />
+            <li role="none">
+              <button
+                type="button"
+                role="menuitem"
+                className="backup-dropdown-item"
+                onClick={openImportDialog}
+                data-testid="import-wishlist-btn"
+              >
+                {labels.importLabel}
+              </button>
+            </li>
+          </ul>
+        )}
+      </div>
+
+      {/* Import dialog */}
+      <dialog
+        ref={dialogRef}
+        className="qr-dialog"
+        onClick={handleBackdropClick}
+        data-testid="import-wishlist-dialog"
+      >
+        <div className="qr-dialog-inner">
+          <h2 className="qr-dialog-title">{labels.importDialogTitle}</h2>
+          <p
+            style={{
+              fontSize: "var(--font-size-label)",
+              color: "var(--color-text-muted)",
+              marginBottom: "var(--space-5)",
+            }}
+          >
+            {labels.importDialogDescription}
+          </p>
+
+          <form onSubmit={handleImportSubmit}>
+            <div style={{ marginBottom: "var(--space-5)" }}>
+              <label
+                htmlFor="import-file-input"
+                style={{
+                  display: "block",
+                  fontSize: "var(--font-size-label)",
+                  marginBottom: "var(--space-2)",
+                }}
+              >
+                {labels.importFileLabel}
+              </label>
+              <input
+                id="import-file-input"
+                ref={fileRef}
+                type="file"
+                accept=".md,text/markdown,text/plain"
+                required
+                data-testid="import-file-input"
+                style={{ display: "block", width: "100%" }}
+              />
+            </div>
+
+            {feedback ? (
+              <p
+                data-testid="import-feedback"
+                style={{
+                  fontSize: "var(--font-size-label)",
+                  color: feedbackOk ? "var(--color-success, green)" : "var(--color-error)",
+                  marginBottom: "var(--space-4)",
+                }}
+              >
+                {feedback}
+              </p>
+            ) : null}
+
+            <div className="qr-dialog-actions">
+              <button
+                type="submit"
+                className="ui-button"
+                disabled={isPending}
+                data-testid="import-submit-btn"
+              >
+                {labels.importSubmitLabel}
+              </button>
+              <button
+                type="button"
+                className="ui-button ui-button-soft"
+                onClick={closeImportDialog}
+                data-testid="import-cancel-btn"
+              >
+                {labels.importCancelLabel}
+              </button>
+            </div>
+          </form>
+        </div>
+      </dialog>
+    </>
+  );
+}

--- a/src/app/_dashboard/qr-code-button.tsx
+++ b/src/app/_dashboard/qr-code-button.tsx
@@ -68,7 +68,7 @@ export function QrCodeButton({ url, labels }: QrCodeButtonProps) {
         </svg>
       </button>
 
-      <dialog ref={dialogRef} className="qr-dialog" onClick={handleBackdropClick}>
+      <dialog ref={dialogRef} className="qr-dialog" data-testid="qr-dialog" onClick={handleBackdropClick}>
         <div className="qr-dialog-inner">
           <h2 className="qr-dialog-title">{labels.qrDialogTitle}</h2>
           <div className="qr-dialog-code" ref={canvasRef}>

--- a/src/app/_dashboard/wishlist-manager.tsx
+++ b/src/app/_dashboard/wishlist-manager.tsx
@@ -27,6 +27,10 @@ import type {
 } from "./item-actions";
 import type { OwnerWishlistItem } from "@/modules/reservation";
 
+type ImportResult =
+  | { status: "success"; wishlists: number; items: number }
+  | { status: "error"; code: "empty" | "invalid-format" | "no-wishlists" | "unknown" };
+
 export type DashboardWishlist = {
   id: string;
   name: string;
@@ -53,6 +57,7 @@ type WishlistManagerProps = {
     prev: RegenerateState,
     formData: FormData,
   ) => Promise<RegenerateState>;
+  importAction: (text: string) => Promise<ImportResult>;
 };
 
 const SELECTED_WISHLIST_COOKIE = "wshka_selected_wishlist";
@@ -67,6 +72,7 @@ export function WishlistManager({
   cancelItemReservationAction,
   cancelOwnerReservationAction,
   regenerateShareLinkAction,
+  importAction,
 }: WishlistManagerProps) {
   const common = useTranslations("common");
   const messages = useTranslations("app");
@@ -145,6 +151,7 @@ export function WishlistManager({
           itemCount={localItems.length}
           onSelect={handleSelectWishlist}
           onCreated={handleSelectWishlist}
+          importAction={importAction}
         />
       </div>
 

--- a/src/app/_dashboard/wishlist-selector.tsx
+++ b/src/app/_dashboard/wishlist-selector.tsx
@@ -5,6 +5,7 @@ import { useTranslations, useLocale } from "@/modules/i18n";
 import { CreateWishlistForm } from "./create-wishlist-form";
 import { RenameWishlistForm } from "./rename-wishlist-form";
 import { DeleteWishlistButton } from "./delete-wishlist-button";
+import { BackupDropdown } from "./backup-dropdown";
 
 function PlusIcon() {
   return (
@@ -69,12 +70,17 @@ type WishlistSelectorEntry = {
   name: string;
 };
 
+type ImportResult =
+  | { status: "success"; wishlists: number; items: number }
+  | { status: "error"; code: "empty" | "invalid-format" | "no-wishlists" | "unknown" };
+
 type WishlistSelectorProps = {
   wishlists: WishlistSelectorEntry[];
   selectedId: string;
   itemCount: number;
   onSelect: (id: string) => void;
   onCreated: (id: string) => void;
+  importAction: (text: string) => Promise<ImportResult>;
 };
 
 export function WishlistSelector({
@@ -83,6 +89,7 @@ export function WishlistSelector({
   itemCount,
   onSelect,
   onCreated,
+  importAction,
 }: WishlistSelectorProps) {
   const messages = useTranslations("app");
   const locale = useLocale();
@@ -186,6 +193,13 @@ export function WishlistSelector({
           <PlusIcon />
           <span className="wishlist-btn-label">{messages.dashboard.wishlists.createLabel}</span>
         </button>
+
+        <BackupDropdown
+          selectedWishlistId={selectedId}
+          labels={messages.dashboard.backup}
+          importAction={importAction}
+          triggerLabel={messages.dashboard.backup.triggerLabel}
+        />
 
         <DeleteWishlistButton wishlistId={selectedId} />
       </div>

--- a/src/app/api/wishlist/export/route.ts
+++ b/src/app/api/wishlist/export/route.ts
@@ -1,0 +1,55 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireCurrentUser } from "@/modules/auth/server/current-user";
+import {
+  getAllUserWishlistsWithItems,
+  getWishlistWithItems,
+} from "@/modules/wishlist/server/items";
+import { formatWishlistsAsMarkdown } from "@/modules/wishlist/export/formatter";
+
+/**
+ * GET /api/wishlist/export
+ * GET /api/wishlist/export?wishlistId=<id>
+ *
+ * Returns a Markdown file attachment with the owner's wishlist data.
+ * Without `wishlistId` — exports all wishlists.
+ * With `wishlistId`  — exports that single wishlist only.
+ */
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  let user: Awaited<ReturnType<typeof requireCurrentUser>>;
+  try {
+    user = await requireCurrentUser();
+  } catch {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const wishlistId = request.nextUrl.searchParams.get("wishlistId");
+
+  const today = new Date().toISOString().slice(0, 10);
+
+  let markdown: string;
+
+  if (wishlistId) {
+    const wishlist = await getWishlistWithItems(wishlistId);
+
+    if (!wishlist || wishlist.userId !== user.id) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+
+    markdown = formatWishlistsAsMarkdown([wishlist], user.email, today);
+  } else {
+    const wishlists = await getAllUserWishlistsWithItems(user.id);
+    markdown = formatWishlistsAsMarkdown(wishlists, user.email, today);
+  }
+
+  const filename = wishlistId
+    ? `wishlist-${today}.md`
+    : `wishlists-${today}.md`;
+
+  return new NextResponse(markdown, {
+    status: 200,
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+      "Content-Disposition": `attachment; filename="${filename}"`,
+    },
+  });
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -11,6 +11,7 @@ import {
 import type { DeleteItemState, ReserveItemState, CancelItemReservationState, CancelOwnerReservationState, RegenerateState } from "./_dashboard/item-actions";
 import { getAllOwnerWishlistsWithReservations, createReservation, cancelReservation, cancelReservationByOwner } from "@/modules/reservation";
 import { deleteCurrentWishlistItem } from "@/modules/wishlist/server/manage-item";
+import { importWishlistsForUser } from "@/modules/wishlist/server/import-wishlists";
 import { WishlistManager, type DashboardWishlist } from "./_dashboard/wishlist-manager";
 import { ScrollHighlight } from "./_dashboard/scroll-highlight";
 import { AutoRefresh } from "@/shared/ui/auto-refresh";
@@ -163,6 +164,7 @@ async function DashboardView({ userId }: { userId: string }) {
         cancelItemReservationAction={cancelItemReservationAction}
         cancelOwnerReservationAction={cancelOwnerReservationAction}
         regenerateShareLinkAction={regenerateShareLinkAction}
+      importAction={importAction}
       />
     </div>
   );
@@ -242,6 +244,13 @@ async function regenerateShareLinkAction(
   } catch {
     return { status: "error" };
   }
+}
+
+async function importAction(text: string) {
+  "use server";
+
+  const user = await requireCurrentUser();
+  return importWishlistsForUser(user.id, text);
 }
 
 // ---------------------------------------------------------------------------

--- a/src/app/styles/dashboard.css
+++ b/src/app/styles/dashboard.css
@@ -807,7 +807,7 @@
   /* Wishlist action buttons row */
   .wishlist-actions-row {
     display: grid;
-    grid-template-columns: repeat(3, 1fr);
+    grid-template-columns: repeat(2, 1fr);
     gap: var(--space-2);
     margin-top: var(--space-3);
   }
@@ -815,6 +815,45 @@
   .wishlist-actions-row .ui-button {
     justify-content: center;
     width: 100%;
+  }
+
+  /* ── Backup dropdown menu ────────────────────────────── */
+  .backup-dropdown-menu {
+    position: absolute;
+    top: calc(100% + var(--space-1));
+    left: 0;
+    z-index: 20;
+    min-width: 13rem;
+    list-style: none;
+    margin: 0;
+    padding: var(--space-1) 0;
+    background: var(--color-bg-surface);
+    border: 1px solid var(--color-border-soft);
+    border-radius: var(--radius-md);
+    box-shadow: var(--shadow-surface);
+  }
+
+  .backup-dropdown-item {
+    display: block;
+    width: 100%;
+    padding: var(--space-2) var(--space-4);
+    text-align: left;
+    font-size: var(--font-size-label);
+    color: var(--color-text-base);
+    background: none;
+    border: none;
+    cursor: pointer;
+    border-radius: 0;
+  }
+
+  .backup-dropdown-item:hover {
+    background: var(--color-bg-subtle);
+  }
+
+  .backup-dropdown-separator {
+    height: 1px;
+    background: var(--color-border-soft);
+    margin: var(--space-1) 0;
   }
 
   /* Wishlist create / rename form */

--- a/src/modules/i18n/dictionaries/en/app.ts
+++ b/src/modules/i18n/dictionaries/en/app.ts
@@ -267,6 +267,24 @@ export const app = {
       reservedLabel: "Status: reserved",
       selfReservedLabel: "Status: reserved by me",
     },
+    backup: {
+      triggerLabel: "Backup",
+      exportAllLabel: "Download all lists",
+      exportOneLabel: "Download this list",
+      importLabel: "Import...",
+      importDialogTitle: "Import wishlists",
+      importDialogDescription:
+        "Upload a .md file exported from Wshka. New lists and wishes will be created — your existing data will not be changed.",
+      importFileLabel: "Choose file",
+      importSubmitLabel: "Import",
+      importCancelLabel: "Cancel",
+      importSuccess: "Imported wishlists: {wishlists}, wishes: {items}.",
+      importErrorEmpty: "The file is empty.",
+      importErrorInvalidFormat:
+        "File format not recognised. Make sure you are uploading a file exported from Wshka.",
+      importErrorNoWishlists: "No wishlists found in the file.",
+      importErrorUnknown: "Import failed. Please try again.",
+    },
   },
   reservations: {
     title: "Reservations",

--- a/src/modules/i18n/dictionaries/ru/app.ts
+++ b/src/modules/i18n/dictionaries/ru/app.ts
@@ -261,6 +261,23 @@ export const app = {
       reservedLabel: "Статус: забронировано",
       selfReservedLabel: "Статус: забронировано мной",
     },
+    backup: {
+      triggerLabel: "Резервная копия",
+      exportAllLabel: "Скачать все списки",
+      exportOneLabel: "Скачать этот список",
+      importLabel: "Импортировать...",
+      importDialogTitle: "Импорт вишлистов",
+      importDialogDescription:
+        "Загрузите файл .md, экспортированный из Wshka. Будут созданы новые списки и желания — существующие данные не изменятся.",
+      importFileLabel: "Выберите файл",
+      importSubmitLabel: "Импортировать",
+      importCancelLabel: "Отмена",
+      importSuccess: "Импортировано вишлистов: {wishlists}, желаний: {items}.",
+      importErrorEmpty: "Файл пуст.",
+      importErrorInvalidFormat: "Формат файла не распознан. Убедитесь, что загружаете файл, экспортированный из Wshka.",
+      importErrorNoWishlists: "В файле не найдено ни одного вишлиста.",
+      importErrorUnknown: "Не удалось выполнить импорт. Попробуйте ещё раз.",
+    },
   },
   reservations: {
     title: "Бронирования",

--- a/src/modules/wishlist/export/formatter.ts
+++ b/src/modules/wishlist/export/formatter.ts
@@ -1,0 +1,53 @@
+import type { WishlistWithItems } from "@/modules/wishlist/server/items";
+
+const EMPTY = "—";
+
+/** Escape pipe characters inside Markdown table cells. */
+function cell(value: string | null | undefined): string {
+  if (!value || value.trim() === "") return EMPTY;
+  return value.replace(/\|/g, "\\|").replace(/\n/g, " ");
+}
+
+/**
+ * Serialise one or more wishlists into a human-readable Markdown string
+ * suitable for storage, sharing, or printing.
+ *
+ * The format is stable and can be round-tripped through `parseWishlistMarkdown`.
+ */
+export function formatWishlistsAsMarkdown(
+  wishlists: WishlistWithItems[],
+  ownerEmail: string,
+  exportDate: string = new Date().toISOString().slice(0, 10),
+): string {
+  const lines: string[] = [];
+
+  lines.push("# Wshka — Мои вишлисты");
+  lines.push("");
+  lines.push(`Владелец: ${ownerEmail}  `);
+  lines.push(`Дата экспорта: ${exportDate}`);
+  lines.push("");
+
+  for (const wishlist of wishlists) {
+    lines.push("---");
+    lines.push("");
+    lines.push(`## ${wishlist.name}`);
+    lines.push("");
+    lines.push("| Название | Ссылка | Заметка | Цена | Валюта |");
+    lines.push("|----------|--------|---------|------|--------|");
+
+    if (wishlist.items.length === 0) {
+      lines.push(`| ${EMPTY} | ${EMPTY} | ${EMPTY} | ${EMPTY} | ${EMPTY} |`);
+    } else {
+      for (const item of wishlist.items) {
+        const price = item.price ? String(item.price) : null;
+        lines.push(
+          `| ${cell(item.title)} | ${cell(item.url)} | ${cell(item.note)} | ${cell(price)} | ${item.currency} |`,
+        );
+      }
+    }
+
+    lines.push("");
+  }
+
+  return lines.join("\n");
+}

--- a/src/modules/wishlist/export/parser.ts
+++ b/src/modules/wishlist/export/parser.ts
@@ -1,0 +1,122 @@
+export type ParsedItem = {
+  title: string;
+  url: string | null;
+  note: string | null;
+  price: string | null;
+  currency: string;
+};
+
+export type ParsedWishlist = {
+  name: string;
+  items: ParsedItem[];
+};
+
+export type ParseResult =
+  | { ok: true; wishlists: ParsedWishlist[] }
+  | { ok: false; error: "empty" | "invalid-format" | "no-wishlists" };
+
+const EMPTY_MARKER = "—";
+const HEADER_RE = /^#{1,2}\s+(.+)$/;
+const ROW_RE = /^\|(.+)\|$/;
+// Matches the separator row: | --- | --- | ...
+const SEPARATOR_RE = /^\|[-| :]+\|$/;
+const EXPECTED_HEADERS = ["Название", "Ссылка", "Заметка", "Цена", "Валюта"];
+
+function unescape(raw: string): string {
+  return raw.replace(/\\\|/g, "|").trim();
+}
+
+function nullIfEmpty(value: string): string | null {
+  const v = unescape(value);
+  return v === "" || v === EMPTY_MARKER ? null : v;
+}
+
+function splitRow(line: string): string[] {
+  // Strip leading/trailing pipe then split
+  return line.slice(1, -1).split("|");
+}
+
+/**
+ * Parse a Markdown string produced by `formatWishlistsAsMarkdown` back into
+ * structured data ready for import.
+ *
+ * The parser is strict about the table header but tolerant of extra whitespace,
+ * trailing newlines, and empty wishlists (placeholder `—` rows are skipped).
+ */
+export function parseWishlistMarkdown(source: string): ParseResult {
+  if (!source || source.trim() === "") {
+    return { ok: false, error: "empty" };
+  }
+
+  const lines = source.split("\n");
+  const wishlists: ParsedWishlist[] = [];
+  let current: ParsedWishlist | null = null;
+  let inTable = false;
+  let headerValidated = false;
+
+  for (const raw of lines) {
+    const line = raw.trimEnd();
+
+    // New wishlist section
+    const headerMatch = HEADER_RE.exec(line);
+    if (headerMatch) {
+      // Only treat ## headings as wishlist sections (skip the # document title)
+      if (line.startsWith("## ")) {
+        if (current) wishlists.push(current);
+        current = { name: headerMatch[1].trim(), items: [] };
+        inTable = false;
+        headerValidated = false;
+      }
+      continue;
+    }
+
+    if (!current) continue;
+
+    // Table rows
+    if (ROW_RE.test(line)) {
+      if (SEPARATOR_RE.test(line)) {
+        // separator row — skip
+        inTable = true;
+        continue;
+      }
+
+      const cols = splitRow(line);
+
+      if (!headerValidated) {
+        // Validate column headers
+        const headers = cols.map((c) => c.trim());
+        const valid = EXPECTED_HEADERS.every((h, i) => headers[i] === h);
+        if (!valid) {
+          return { ok: false, error: "invalid-format" };
+        }
+        headerValidated = true;
+        inTable = true;
+        continue;
+      }
+
+      if (!inTable) continue;
+      if (cols.length < 5) continue;
+
+      const title = nullIfEmpty(cols[0] ?? "");
+      if (!title) continue; // placeholder empty row — skip
+
+      const url = nullIfEmpty(cols[1] ?? "");
+      const note = nullIfEmpty(cols[2] ?? "");
+      const rawPrice = nullIfEmpty(cols[3] ?? "");
+      const rawCurrency = (cols[4] ?? "").trim();
+
+      const price = rawPrice !== null && /^\d+$/.test(rawPrice) ? rawPrice : null;
+      const currency = /^[A-Z]{3}$/.test(rawCurrency) ? rawCurrency : "RUB";
+
+      current.items.push({ title, url, note, price, currency });
+    }
+  }
+
+  if (current) wishlists.push(current);
+
+  if (wishlists.length === 0) {
+    return { ok: false, error: "no-wishlists" };
+  }
+
+  return { ok: true, wishlists };
+}

--- a/src/modules/wishlist/server/import-wishlists.ts
+++ b/src/modules/wishlist/server/import-wishlists.ts
@@ -1,0 +1,84 @@
+import { parseWishlistMarkdown } from "@/modules/wishlist/export/parser";
+import { createWishlist } from "@/modules/wishlist/server/current-wishlist";
+import { wishlistItems } from "@/modules/wishlist/db/schema";
+
+export type ImportWishlistsResult =
+  | { status: "success"; wishlists: number; items: number }
+  | { status: "error"; code: "empty" | "invalid-format" | "no-wishlists" | "unknown" };
+
+/**
+ * Parse a Markdown backup file and create the contained wishlists and items
+ * for the given user. Existing data is never overwritten or merged.
+ *
+ * If a wishlist name collides with an existing one, a numeric suffix is
+ * appended until a unique name is found (e.g. "My list (2)").
+ */
+export async function importWishlistsForUser(
+  userId: string,
+  markdownText: string,
+): Promise<ImportWishlistsResult> {
+  const parsed = parseWishlistMarkdown(markdownText);
+
+  if (!parsed.ok) {
+    return { status: "error", code: parsed.error };
+  }
+
+  try {
+    const db = await getDb();
+    let wishlistsCreated = 0;
+    let itemsCreated = 0;
+
+    for (const parsedWishlist of parsed.wishlists) {
+      // Find a unique name for this wishlist
+      let name = parsedWishlist.name;
+      let attempt = 0;
+      let wishlistId: string | null = null;
+
+      while (wishlistId === null) {
+        const candidateName = attempt === 0 ? name : `${parsedWishlist.name} (${attempt + 1})`;
+        const result = await createWishlist(userId, candidateName);
+
+        if (result.status === "success") {
+          wishlistId = result.wishlistId;
+        } else if (result.code === "duplicate") {
+          attempt++;
+          if (attempt > 99) {
+            // Safety valve — should never happen in practice
+            return { status: "error", code: "unknown" };
+          }
+        } else {
+          return { status: "error", code: "unknown" };
+        }
+      }
+
+      wishlistsCreated++;
+
+      // Insert items directly — they come from a trusted export, so we skip
+      // the heavy validation layer and only sanitise the minimum required.
+      const itemValues = parsedWishlist.items
+        .filter((item) => item.title.trim() !== "")
+        .map((item) => ({
+          wishlistId,
+          title: item.title.slice(0, 255),
+          url: item.url ? item.url.slice(0, 2048) : null,
+          note: item.note ?? null,
+          price: item.price ?? null,
+          currency: item.currency,
+        }));
+
+      if (itemValues.length > 0) {
+        await db.insert(wishlistItems).values(itemValues);
+        itemsCreated += itemValues.length;
+      }
+    }
+
+    return { status: "success", wishlists: wishlistsCreated, items: itemsCreated };
+  } catch {
+    return { status: "error", code: "unknown" };
+  }
+}
+
+async function getDb() {
+  const { db } = await import("@/shared/db");
+  return db;
+}

--- a/tests/e2e/qr-code.spec.ts
+++ b/tests/e2e/qr-code.spec.ts
@@ -13,7 +13,7 @@ test("owner can open the QR code modal and close it", async ({ page }) => {
   await test.step("clicking QR button opens the modal with the QR code", async () => {
     await page.getByRole("button", { name: "QR" }).click();
 
-    const dialog = page.locator("dialog.qr-dialog");
+    const dialog = page.getByTestId("qr-dialog");
     await expect(dialog).toBeVisible();
     await expect(dialog.getByRole("button", { name: "Скачать PNG" })).toBeVisible();
     await expect(dialog.getByRole("button", { name: "Закрыть" })).toBeVisible();
@@ -21,8 +21,8 @@ test("owner can open the QR code modal and close it", async ({ page }) => {
   });
 
   await test.step("close button dismisses the modal", async () => {
-    await page.getByRole("button", { name: "Закрыть" }).click();
-    await expect(page.locator("dialog.qr-dialog")).not.toBeVisible();
+    await page.getByTestId("qr-dialog").getByRole("button", { name: "Закрыть" }).click();
+    await expect(page.getByTestId("qr-dialog")).not.toBeVisible();
   });
 });
 

--- a/tests/e2e/wishlist-export-import.spec.ts
+++ b/tests/e2e/wishlist-export-import.spec.ts
@@ -1,0 +1,107 @@
+import { randomUUID } from "node:crypto";
+import path from "node:path";
+import fs from "node:fs/promises";
+import os from "node:os";
+import { expect, test } from "@playwright/test";
+
+test("owner can export wishlists and re-import them", async ({ page }) => {
+  const runId = randomUUID().slice(0, 8);
+  const credentials = { email: `export-test-${runId}@example.com`, password: "password123" };
+  const itemTitle = `Export item ${runId}`;
+
+  // ── Register ──────────────────────────────────────────────────────────────
+  await page.goto("/register");
+  await page.getByLabel("Email").fill(credentials.email);
+  await page.getByLabel("Пароль", { exact: true }).fill(credentials.password);
+  await page.getByLabel("Повторите пароль").fill(credentials.password);
+  await page.locator("#consent").check();
+  await page.getByRole("button", { name: "Создать аккаунт" }).click();
+
+  // Log in
+  await page.goto("/login");
+  await page.getByLabel("Email").fill(credentials.email);
+  await page.getByLabel("Пароль", { exact: true }).fill(credentials.password);
+  await page.getByRole("button", { name: "Войти" }).click();
+  await expect(page).toHaveURL(/\/(?:\?.*)?$/);
+
+  // ── Add an item ───────────────────────────────────────────────────────────
+  await page.getByTestId("add-item-toggle").click();
+  const createForm = page.getByTestId("wishlist-create-form");
+  await createForm.getByLabel("Название").fill(itemTitle);
+  await createForm.getByLabel("Цена").fill("999");
+  await createForm.getByRole("button", { name: "Добавить", exact: true }).click();
+  await expect(page.getByRole("heading", { name: itemTitle, exact: true })).toBeVisible();
+
+  // ── Backup dropdown opens and shows all actions ──────────────────────────
+  await test.step("backup dropdown opens and contains export/import actions", async () => {
+    await page.getByTestId("backup-dropdown-trigger").click();
+    const menu = page.getByTestId("backup-dropdown-menu");
+    await expect(menu).toBeVisible();
+    await expect(page.getByTestId("export-wishlist-btn")).toBeVisible();
+    await expect(page.getByTestId("export-all-btn")).toBeVisible();
+    await expect(page.getByTestId("import-wishlist-btn")).toBeVisible();
+    // Close dropdown by clicking elsewhere
+    await page.keyboard.press("Escape");
+    await page.locator("body").click({ position: { x: 10, y: 10 } });
+  });
+
+  // ── Export via API and verify Markdown content ────────────────────────────
+  await test.step("export API returns valid Markdown with item", async () => {
+    const response = await page.request.get("/api/wishlist/export");
+    expect(response.status()).toBe(200);
+    expect(response.headers()["content-type"]).toContain("text/markdown");
+    expect(response.headers()["content-disposition"]).toContain("attachment");
+    const body = await response.text();
+    expect(body).toContain("# Wshka — Мои вишлисты");
+    expect(body).toContain(itemTitle);
+    expect(body).toContain("999");
+  });
+
+  // ── Import dialog opens ───────────────────────────────────────────────────
+  await test.step("import dialog opens and closes", async () => {
+    await page.getByTestId("backup-dropdown-trigger").click();
+    await page.getByTestId("import-wishlist-btn").click();
+    await expect(page.getByTestId("import-wishlist-dialog")).toBeVisible();
+    await page.getByTestId("import-cancel-btn").click();
+    await expect(page.getByTestId("import-wishlist-dialog")).not.toBeVisible();
+  });
+
+  // ── Import a valid file ───────────────────────────────────────────────────
+  await test.step("import creates a new wishlist from a valid .md file", async () => {
+    const importedTitle = `Imported item ${runId}`;
+    const md = [
+      "# Wshka — Мои вишлисты",
+      "",
+      `Владелец: ${credentials.email}`,
+      "Дата экспорта: 2026-05-19",
+      "",
+      "---",
+      "",
+      `## Импортированный список ${runId}`,
+      "",
+      "| Название | Ссылка | Заметка | Цена | Валюта |",
+      "|----------|--------|---------|------|--------|",
+      `| ${importedTitle} | — | — | 500 | RUB |`,
+      "",
+    ].join("\n");
+
+    // Write the file to a temp dir and use Playwright's file chooser
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "wshka-"));
+    const filePath = path.join(tmpDir, "test-import.md");
+    await fs.writeFile(filePath, md, "utf-8");
+
+    await page.getByTestId("backup-dropdown-trigger").click();
+    await page.getByTestId("import-wishlist-btn").click();
+    await expect(page.getByTestId("import-wishlist-dialog")).toBeVisible();
+
+    const fileInput = page.getByTestId("import-file-input");
+    await fileInput.setInputFiles(filePath);
+    await page.getByTestId("import-submit-btn").click();
+
+    const feedback = page.getByTestId("import-feedback");
+    await expect(feedback).toBeVisible();
+    await expect(feedback).toContainText("1");
+
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+});

--- a/tests/unit/wishlist-export-formatter.test.ts
+++ b/tests/unit/wishlist-export-formatter.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+import { formatWishlistsAsMarkdown } from "../../src/modules/wishlist/export/formatter";
+import type { WishlistWithItems } from "../../src/modules/wishlist/server/items";
+
+function makeWishlist(
+  name: string,
+  items: WishlistWithItems["items"] = [],
+): WishlistWithItems {
+  return {
+    id: "w1",
+    userId: "u1",
+    name,
+    isActive: true,
+    createdAt: new Date("2026-01-01"),
+    updatedAt: new Date("2026-01-01"),
+    items,
+  };
+}
+
+function makeItem(overrides: Partial<WishlistWithItems["items"][number]> = {}): WishlistWithItems["items"][number] {
+  return {
+    id: "i1",
+    wishlistId: "w1",
+    title: "Test item",
+    url: null,
+    note: null,
+    price: null,
+    currency: "RUB",
+    starred: false,
+    createdAt: new Date("2026-01-01"),
+    updatedAt: new Date("2026-01-01"),
+    ...overrides,
+  };
+}
+
+describe("formatWishlistsAsMarkdown", () => {
+  it("includes the document title, owner, and date", () => {
+    const md = formatWishlistsAsMarkdown([], "user@example.com", "2026-05-19");
+    expect(md).toContain("# Wshka — Мои вишлисты");
+    expect(md).toContain("Владелец: user@example.com");
+    expect(md).toContain("Дата экспорта: 2026-05-19");
+  });
+
+  it("creates a ## section per wishlist", () => {
+    const wishlists = [makeWishlist("День рождения"), makeWishlist("Новогодний")];
+    const md = formatWishlistsAsMarkdown(wishlists, "u@e.com", "2026-01-01");
+    expect(md).toContain("## День рождения");
+    expect(md).toContain("## Новогодний");
+  });
+
+  it("includes the table header row", () => {
+    const md = formatWishlistsAsMarkdown([makeWishlist("Test")], "u@e.com", "2026-01-01");
+    expect(md).toContain("| Название | Ссылка | Заметка | Цена | Валюта |");
+  });
+
+  it("renders item fields correctly", () => {
+    const item = makeItem({
+      title: "Книга",
+      url: "https://example.com",
+      note: "Издание 2023",
+      price: "800",
+      currency: "RUB",
+    });
+    const md = formatWishlistsAsMarkdown([makeWishlist("W", [item])], "u@e.com", "2026-01-01");
+    expect(md).toContain("Книга");
+    expect(md).toContain("https://example.com");
+    expect(md).toContain("Издание 2023");
+    expect(md).toContain("800");
+    expect(md).toContain("RUB");
+  });
+
+  it("renders — for null fields", () => {
+    const item = makeItem({ title: "Плед", url: null, note: null, price: null });
+    const md = formatWishlistsAsMarkdown([makeWishlist("W", [item])], "u@e.com", "2026-01-01");
+    // Three null fields rendered as —
+    const matches = md.match(/—/g) ?? [];
+    expect(matches.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it("escapes pipe characters in cell values", () => {
+    const item = makeItem({ title: "A | B" });
+    const md = formatWishlistsAsMarkdown([makeWishlist("W", [item])], "u@e.com", "2026-01-01");
+    expect(md).toContain("A \\| B");
+  });
+
+  it("renders a placeholder row for an empty wishlist", () => {
+    const md = formatWishlistsAsMarkdown([makeWishlist("Empty")], "u@e.com", "2026-01-01");
+    const lines = md.split("\n");
+    const dataRows = lines.filter(
+      (l) => l.startsWith("|") && !l.includes("---") && !l.includes("Название"),
+    );
+    expect(dataRows.length).toBe(1);
+    expect(dataRows[0]).toContain("—");
+  });
+});

--- a/tests/unit/wishlist-export-parser.test.ts
+++ b/tests/unit/wishlist-export-parser.test.ts
@@ -1,0 +1,201 @@
+import { describe, expect, it } from "vitest";
+import { parseWishlistMarkdown } from "../../src/modules/wishlist/export/parser";
+import { formatWishlistsAsMarkdown } from "../../src/modules/wishlist/export/formatter";
+import type { WishlistWithItems } from "../../src/modules/wishlist/server/items";
+
+function makeWishlist(
+  name: string,
+  items: WishlistWithItems["items"] = [],
+): WishlistWithItems {
+  return {
+    id: "w1",
+    userId: "u1",
+    name,
+    isActive: true,
+    createdAt: new Date("2026-01-01"),
+    updatedAt: new Date("2026-01-01"),
+    items,
+  };
+}
+
+function makeItem(overrides: Partial<WishlistWithItems["items"][number]> = {}): WishlistWithItems["items"][number] {
+  return {
+    id: "i1",
+    wishlistId: "w1",
+    title: "Книга",
+    url: null,
+    note: null,
+    price: null,
+    currency: "RUB",
+    starred: false,
+    createdAt: new Date("2026-01-01"),
+    updatedAt: new Date("2026-01-01"),
+    ...overrides,
+  };
+}
+
+// ── Error cases ──────────────────────────────────────────────────────────────
+
+describe("parseWishlistMarkdown — error cases", () => {
+  it("returns empty error for empty input", () => {
+    expect(parseWishlistMarkdown("")).toEqual({ ok: false, error: "empty" });
+    expect(parseWishlistMarkdown("   \n  ")).toEqual({ ok: false, error: "empty" });
+  });
+
+  it("returns no-wishlists error when no ## sections are found", () => {
+    const result = parseWishlistMarkdown("# Just a title\n\nSome prose.");
+    expect(result).toEqual({ ok: false, error: "no-wishlists" });
+  });
+
+  it("returns invalid-format when table headers do not match", () => {
+    const md = `
+## My list
+
+| Name | Link | Note |
+|------|------|------|
+| Item |  |  |
+`;
+    expect(parseWishlistMarkdown(md)).toEqual({ ok: false, error: "invalid-format" });
+  });
+});
+
+// ── Success cases ────────────────────────────────────────────────────────────
+
+describe("parseWishlistMarkdown — success cases", () => {
+  it("parses a single wishlist with one item", () => {
+    const md = `
+## День рождения
+
+| Название | Ссылка | Заметка | Цена | Валюта |
+|----------|--------|---------|------|--------|
+| Книга | https://example.com | Издание 2023 | 800 | RUB |
+`;
+    const result = parseWishlistMarkdown(md);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.wishlists).toHaveLength(1);
+    const [wl] = result.wishlists;
+    expect(wl.name).toBe("День рождения");
+    expect(wl.items).toHaveLength(1);
+    const [item] = wl.items;
+    expect(item.title).toBe("Книга");
+    expect(item.url).toBe("https://example.com");
+    expect(item.note).toBe("Издание 2023");
+    expect(item.price).toBe("800");
+    expect(item.currency).toBe("RUB");
+  });
+
+  it("parses multiple wishlists", () => {
+    const md = `
+## Первый
+
+| Название | Ссылка | Заметка | Цена | Валюта |
+|----------|--------|---------|------|--------|
+| A | — | — | — | RUB |
+
+---
+
+## Второй
+
+| Название | Ссылка | Заметка | Цена | Валюта |
+|----------|--------|---------|------|--------|
+| B | — | — | — | USD |
+`;
+    const result = parseWishlistMarkdown(md);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.wishlists).toHaveLength(2);
+    expect(result.wishlists[0].name).toBe("Первый");
+    expect(result.wishlists[1].name).toBe("Второй");
+  });
+
+  it("treats — as null for optional fields", () => {
+    const md = `
+## W
+
+| Название | Ссылка | Заметка | Цена | Валюта |
+|----------|--------|---------|------|--------|
+| Item | — | — | — | RUB |
+`;
+    const result = parseWishlistMarkdown(md);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const [item] = result.wishlists[0].items;
+    expect(item.url).toBeNull();
+    expect(item.note).toBeNull();
+    expect(item.price).toBeNull();
+  });
+
+  it("skips placeholder rows (empty name / —)", () => {
+    const md = `
+## Empty list
+
+| Название | Ссылка | Заметка | Цена | Валюта |
+|----------|--------|---------|------|--------|
+| — | — | — | — | — |
+`;
+    const result = parseWishlistMarkdown(md);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.wishlists[0].items).toHaveLength(0);
+  });
+
+  it("falls back to RUB for unrecognised currency codes", () => {
+    const md = `
+## W
+
+| Название | Ссылка | Заметка | Цена | Валюта |
+|----------|--------|---------|------|--------|
+| Item | — | — | — | INVALID |
+`;
+    const result = parseWishlistMarkdown(md);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.wishlists[0].items[0].currency).toBe("RUB");
+  });
+});
+
+// ── Round-trip ───────────────────────────────────────────────────────────────
+
+describe("formatter → parser round-trip", () => {
+  it("preserves all fields through a full export → import cycle", () => {
+    const original: WishlistWithItems[] = [
+      makeWishlist("День рождения", [
+        makeItem({ title: "Наушники", url: "https://sony.com", note: "Чёрные", price: "15000", currency: "RUB" }),
+        makeItem({ id: "i2", title: "Книга", url: null, note: null, price: null, currency: "RUB" }),
+      ]),
+      makeWishlist("Новогодний", [
+        makeItem({ id: "i3", wishlistId: "w2", title: "Плед", url: null, note: null, price: "3000", currency: "EUR" }),
+      ]),
+    ];
+
+    const md = formatWishlistsAsMarkdown(original, "test@example.com", "2026-05-19");
+    const result = parseWishlistMarkdown(md);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    expect(result.wishlists).toHaveLength(2);
+
+    const [wl1, wl2] = result.wishlists;
+    expect(wl1.name).toBe("День рождения");
+    expect(wl1.items).toHaveLength(2);
+    expect(wl1.items[0]).toMatchObject({
+      title: "Наушники",
+      url: "https://sony.com",
+      note: "Чёрные",
+      price: "15000",
+      currency: "RUB",
+    });
+    expect(wl1.items[1]).toMatchObject({
+      title: "Книга",
+      url: null,
+      note: null,
+      price: null,
+      currency: "RUB",
+    });
+
+    expect(wl2.name).toBe("Новогодний");
+    expect(wl2.items[0]).toMatchObject({ title: "Плед", price: "3000", currency: "EUR" });
+  });
+});


### PR DESCRIPTION
Closes #197.

Add wishlist backup: owners can export all wishlists (or a single one)
as a human-readable Markdown file and restore them via import.

## What changed

- `src/modules/wishlist/export/formatter.ts` — serialise to Markdown
- `src/modules/wishlist/export/parser.ts` — parse Markdown to import data
- `src/modules/wishlist/server/import-wishlists.ts` — create wishlists and
  items from parsed data; duplicate names get a numeric suffix
- `src/app/api/wishlist/export/route.ts` — GET endpoint, returns `.md`
  attachment; `?wishlistId=` scopes to one list
- `src/app/_dashboard/backup-dropdown.tsx` — trigger button + dropdown
  menu (download this, download all, import) with embedded import dialog
- `src/app/_dashboard/wishlist-selector.tsx` — replaced separate buttons
  with `BackupDropdown`; actions row is now a 2×2 grid (mobile-friendly)
- `src/app/page.tsx` — added `importAction` server action
- i18n updated (ru + en) with all backup labels
- `qr-code-button.tsx` — added `data-testid="qr-dialog"` to avoid
  selector ambiguity with the import dialog

## How to verify

- Log in → open the "Резервная копия" dropdown in the wishlist header
- Click "Скачать все списки" — a `.md` file downloads with all wishlists
- Click "Скачать этот список" — a `.md` file downloads with the current list
- Open the downloaded file in any text editor — content is readable
- Click "Импортировать..." → upload the exported file → new wishlists appear
- Existing data is unchanged after import

## Tests

- `tests/unit/wishlist-export-formatter.test.ts` — 7 unit tests
- `tests/unit/wishlist-export-parser.test.ts` — 9 unit tests + 1 round-trip
- `tests/e2e/wishlist-export-import.spec.ts` — full export/import flow

## Documentation

- `CHANGELOG.md` — added entry to [Unreleased]
- `docs/master-plan.md` — updated M11-I2 scope, format, and acceptance criteria